### PR TITLE
Project x plugins

### DIFF
--- a/data/transform/models/marts/telemetry/project_plugins.sql
+++ b/data/transform/models/marts/telemetry/project_plugins.sql
@@ -40,9 +40,29 @@ plugins_per_project AS (
             )
             FROM plugins
             WHERE plugins.date_day BETWEEN DATEADD(
+                    DAY, -28, date_dim.date_day
+                ) AND date_dim.date_day
+        ) AS projects_28d,
+        (
+            SELECT COUNT(
+                DISTINCT
+                plugins.project_id,
+                plugins.plugin_category
+            )
+            FROM plugins
+            WHERE plugins.date_day BETWEEN DATEADD(
+                    DAY, -28, date_dim.date_day
+                ) AND date_dim.date_day
+        ) AS plugin_categories_28d,
+        (
+            SELECT COUNT(
+                DISTINCT plugins.project_id
+            )
+            FROM plugins
+            WHERE plugins.date_day BETWEEN DATEADD(
                     DAY, -14, date_dim.date_day
                 ) AND date_dim.date_day
-        ) AS projects,
+        ) AS projects_14d,
         (
             SELECT COUNT(
                 DISTINCT
@@ -53,15 +73,41 @@ plugins_per_project AS (
             WHERE plugins.date_day BETWEEN DATEADD(
                     DAY, -14, date_dim.date_day
                 ) AND date_dim.date_day
-        ) AS categories
+        ) AS plugin_categories_14d,
+        (
+            SELECT COUNT(
+                DISTINCT plugins.project_id
+            )
+            FROM plugins
+            WHERE plugins.date_day BETWEEN DATEADD(
+                    DAY, -7, date_dim.date_day
+                ) AND date_dim.date_day
+        ) AS projects_7d,
+        (
+            SELECT COUNT(
+                DISTINCT
+                plugins.project_id,
+                plugins.plugin_category
+            )
+            FROM plugins
+            WHERE plugins.date_day BETWEEN DATEADD(
+                    DAY, -7, date_dim.date_day
+                ) AND date_dim.date_day
+        ) AS plugin_categories_7d
     FROM {{ ref('date_dim') }}
     WHERE date_dim.date_day <= CURRENT_TIMESTAMP()
-    HAVING projects > 0
+    HAVING projects_28d > 0
 )
 
 SELECT
     date_day,
-    projects,
-    categories,
-    categories / projects AS avg_plugin_per_project
+    projects_28d,
+    plugin_categories_28d,
+    projects_14d,
+    plugin_categories_14d,
+    projects_7d,
+    plugin_categories_7d,
+    plugin_categories_28d / projects_28d AS app_28d,
+    plugin_categories_14d / projects_14d AS app_14d,
+    plugin_categories_7d / projects_7d AS app_7d
 FROM plugins_per_project

--- a/data/transform/models/marts/telemetry/project_plugins.sql
+++ b/data/transform/models/marts/telemetry/project_plugins.sql
@@ -28,14 +28,20 @@ plugins_per_project AS (
     SELECT
         date_dim.date_day,
         (
-            SELECT COUNT(DISTINCT project_id)
+            SELECT COUNT(
+                DISTINCT plugins.project_id
+            )
             FROM plugins
             WHERE plugins.date_day BETWEEN DATEADD(
                     DAY, -14, date_dim.date_day
                 ) AND date_dim.date_day
         ) AS projects,
         (
-            SELECT COUNT(DISTINCT project_id, plugin_category)
+            SELECT COUNT(
+                DISTINCT
+                plugins.project_id,
+                plugins.plugin_category
+            )
             FROM plugins
             WHERE plugins.date_day BETWEEN DATEADD(
                     DAY, -14, date_dim.date_day

--- a/data/transform/models/marts/telemetry/project_plugins.sql
+++ b/data/transform/models/marts/telemetry/project_plugins.sql
@@ -14,6 +14,8 @@ WITH plugins AS (
         ON plugin_executions.execution_id = execution_dim.execution_id
     LEFT JOIN {{ ref('project_dim') }}
         ON plugin_executions.project_id = project_dim.project_id
+    LEFT JOIN {{ ref('unstructured_executions') }}
+        ON plugin_executions.execution_id = unstructured_executions.execution_id
     WHERE
         execution_dim.is_exec_event
         AND DATEDIFF(
@@ -21,6 +23,11 @@ WITH plugins AS (
             project_dim.first_event_at::TIMESTAMP,
             plugin_executions.event_ts::DATE
         ) >= 7
+        -- TODO: move project_uuid_source upstream to execution_dim
+        AND COALESCE(
+            unstructured_executions.project_uuid_source,
+            ''
+        ) != 'random'
 
 ),
 

--- a/data/transform/models/marts/telemetry/project_plugins.sql
+++ b/data/transform/models/marts/telemetry/project_plugins.sql
@@ -1,37 +1,54 @@
-WITH base_week AS (
-    SELECT
-        project_id,
-        DATE_TRUNC('week', event_ts) AS week_date,
-        COUNT(DISTINCT plugin_category) AS plugin_cnt
-    FROM {{ ref('fact_plugin_usage') }}
-    GROUP BY 1, 2
+WITH plugins AS (
+    SELECT DISTINCT
+        plugin_executions.event_ts::DATE AS date_day,
+        plugin_executions.project_id,
+        CASE
+            WHEN
+                plugin_executions.plugin_category NOT IN (
+                    'singer', 'dbt', 'great_expectations', 'superset', 'airflow'
+                ) THEN 'other'
+            ELSE plugin_executions.plugin_category
+        END AS plugin_category
+    FROM {{ ref('plugin_executions') }}
+    LEFT JOIN {{ ref('execution_dim') }}
+        ON plugin_executions.execution_id = execution_dim.execution_id
+    LEFT JOIN {{ ref('project_dim') }}
+        ON plugin_executions.project_id = project_dim.project_id
+    WHERE
+        execution_dim.is_exec_event
+        AND DATEDIFF(
+            'day',
+            project_dim.first_event_at::TIMESTAMP,
+            plugin_executions.event_ts::DATE
+        ) >= 7
+
 ),
 
-base_month AS (
+plugins_per_project AS (
     SELECT
-        project_id,
-        DATE_TRUNC('month', event_ts) AS month_date,
-        COUNT(DISTINCT plugin_category) AS plugin_cnt
-    FROM {{ ref('fact_plugin_usage') }}
-    GROUP BY 1, 2
+        date_dim.date_day,
+        (
+            SELECT COUNT(DISTINCT project_id)
+            FROM plugins
+            WHERE plugins.date_day BETWEEN DATEADD(
+                    DAY, -14, date_dim.date_day
+                ) AND date_dim.date_day
+        ) AS projects,
+        (
+            SELECT COUNT(DISTINCT project_id, plugin_category)
+            FROM plugins
+            WHERE plugins.date_day BETWEEN DATEADD(
+                    DAY, -14, date_dim.date_day
+                ) AND date_dim.date_day
+        ) AS categories
+    FROM {{ ref('date_dim') }}
+    WHERE date_dim.date_day <= CURRENT_TIMESTAMP()
+    HAVING projects > 0
 )
 
 SELECT
-    week_date AS agg_period_date,
-    'week' AS agg_period,
-    COUNT(project_id) AS total_projects,
-    SUM(plugin_cnt) AS plugin_score,
-    AVG(plugin_cnt) AS avg_plugin_per_proj
-FROM base_week
-GROUP BY 1, 2
-
-UNION ALL
-
-SELECT
-    month_date AS agg_period_date,
-    'month' AS agg_period,
-    COUNT(project_id) AS total_projects,
-    SUM(plugin_cnt) AS plugin_score,
-    AVG(plugin_cnt) AS avg_plugin_per_proj
-FROM base_month
-GROUP BY 1, 2
+    date_day,
+    projects,
+    categories,
+    categories / projects AS avg_plugin_per_project
+FROM plugins_per_project


### PR DESCRIPTION
Closes https://github.com/meltano/internal-data/issues/1 and https://github.com/meltano/squared/issues/271

Implements the projects x plugin types metric.

- Like I documented in the handbook PR https://github.com/meltano/handbook/pull/286 I thought 14 days was an appropriate look back window. I tried 7 but moving to 14 gave it a 15-20% increase so I wonder if we have users who run pipelines less than once a week that are getting dropped which would make sense comparing to the 28d active number. Again happy to change back if you guys prefer.
- In exploring the difference between the 28d active project counts and this project count, I noticed that the filter were using here to exclude projects that are less than a week old caused the decrease.
- Another difference is that the 28d active metric uses >1 executions which we arent implementing here. I dont see any reason why the 2 metrics would need to match but wanted to call it out in case were curious.
- I excluded "random" project_ids but I also did a quick query and it didnt make any difference to the numbers so theres either very few of them or they're not doing anything of substance (e.g we saw a lot of `meltano discover` when exploring at one point).
