### PR TITLE
migrate 28d projects to new models

### DIFF
--- a/data/transform/models/marts/telemetry/active_projects_28d.sql
+++ b/data/transform/models/marts/telemetry/active_projects_28d.sql
@@ -2,36 +2,41 @@
     config(materialized='table')
 }}
 
-WITH dates AS (
-
-    SELECT DISTINCT event_date FROM {{ ref('fact_cli_events') }}
-
-)
-
 SELECT
-    event_date,
+    date_day AS event_date,
     (
         SELECT COUNT(DISTINCT event_exec.project_id)
         FROM
             (
                 SELECT
-                    fact_cli_events.event_date,
-                    fact_cli_events.project_id,
+                    fact_cli_executions.date_day,
+                    fact_cli_executions.project_id,
                     SUM(
                         CASE
                             WHEN
-                                fact_cli_events.is_exec_event
-                                THEN fact_cli_events.event_count
+                                fact_cli_executions.cli_command IN (
+                                    'meltano invoke',
+                                    'meltano elt',
+                                    'meltano run',
+                                    'meltano test',
+                                    'meltano ui',
+                                    'invoke',
+                                    'elt',
+                                    'run',
+                                    'test',
+                                    'ui'
+                                )
+                                THEN fact_cli_executions.event_count
                             ELSE 0
                         END
                     ) AS exec_count
-                FROM {{ ref('fact_cli_events') }}
+                FROM {{ ref('fact_cli_executions') }}
                 GROUP BY 1, 2
             ) AS event_exec
         WHERE
-            event_exec.event_date BETWEEN DATEADD(
-                DAY, -28, dates.event_date
-            ) AND dates.event_date
+            event_exec.date_day BETWEEN DATEADD(
+                DAY, -28, date_dim.date_day
+            ) AND date_dim.date_day
             AND event_exec.exec_count > 1
     ) AS exec_greater_1_monthly,
     (
@@ -39,22 +44,19 @@ SELECT
         FROM
             (
                 SELECT
-                    fact_cli_events.event_date,
-                    fact_cli_events.project_id,
+                    fact_cli_executions.date_day,
+                    fact_cli_executions.project_id,
                     COUNT(DISTINCT
-                        CASE
-                            WHEN
-                                fact_cli_events.is_pipeline_exec_event
-                                THEN fact_cli_events.command
-                        END
+                        fact_cli_executions.pipeline_fk
                     ) AS pipeline_count
-                FROM {{ ref('fact_cli_events') }}
+                FROM {{ ref('fact_cli_executions') }}
                 GROUP BY 1, 2
             ) AS pipe_exec
         WHERE
-            pipe_exec.event_date BETWEEN DATEADD(
-                DAY, -28, dates.event_date
-            ) AND dates.event_date
+            pipe_exec.date_day BETWEEN DATEADD(
+                DAY, -28, date_dim.date_day
+            ) AND date_dim.date_day
             AND pipe_exec.pipeline_count > 1
     ) AS unique_pipe_greater_1_monthly
-FROM dates
+FROM {{ ref('date_dim') }}
+WHERE date_day BETWEEN DATEADD(YEAR, -2, CURRENT_TIMESTAMP()) AND CURRENT_TIMESTAMP()

--- a/data/transform/models/marts/telemetry/active_projects_28d.sql
+++ b/data/transform/models/marts/telemetry/active_projects_28d.sql
@@ -15,11 +15,6 @@ SELECT
                         CASE
                             WHEN
                                 fact_cli_executions.cli_command IN (
-                                    'meltano invoke',
-                                    'meltano elt',
-                                    'meltano run',
-                                    'meltano test',
-                                    'meltano ui',
                                     'invoke',
                                     'elt',
                                     'run',

--- a/data/transform/models/marts/telemetry/active_projects_28d.sql
+++ b/data/transform/models/marts/telemetry/active_projects_28d.sql
@@ -54,4 +54,6 @@ SELECT
             AND pipe_exec.pipeline_count > 1
     ) AS unique_pipe_greater_1_monthly
 FROM {{ ref('date_dim') }}
-WHERE date_day BETWEEN DATEADD(YEAR, -2, CURRENT_TIMESTAMP()) AND CURRENT_TIMESTAMP()
+WHERE date_day
+    BETWEEN DATEADD(YEAR, -2, CURRENT_TIMESTAMP())
+    AND CURRENT_TIMESTAMP()

--- a/data/transform/models/marts/telemetry/base/cli_executions_base.sql
+++ b/data/transform/models/marts/telemetry/base/cli_executions_base.sql
@@ -27,10 +27,6 @@ unstruct_prep AS (
                 'run',
                 'test',
                 'ui'
-            )
-            OR (
-                struct_command_category = 'meltano schedule'
-                AND cli_command LIKE '% run %'
             ),
             FALSE)
         ) AS is_exec_event,
@@ -42,10 +38,6 @@ unstruct_prep AS (
                 'invoke',
                 'elt',
                 'run'
-            )
-            OR (
-                struct_command_category = 'meltano schedule'
-                AND cli_command LIKE '% run %'
             ),
             FALSE
             )


### PR DESCRIPTION
Relates to https://github.com/meltano/squared/issues/279

- use new fact_cli_executions model
- use date_dim
- use pipeline pk vs parsing the command