### PR TITLE
ignore pipelinewise prefix for hub metrics

### DIFF
--- a/data/transform/models/publish/meltano_hub/fact_hub_metrics.sql
+++ b/data/transform/models/publish/meltano_hub/fact_hub_metrics.sql
@@ -27,7 +27,11 @@ rename_join AS (
         COALESCE(plugin_use_3m.project_count, 0) AS meltano_project_id_count_3m
     FROM {{ ref('fact_repo_metrics') }}
     LEFT JOIN plugin_use_3m
-        ON fact_repo_metrics.repo_name = plugin_use_3m.plugin_name
+        ON REPLACE(
+            fact_repo_metrics.repo_name,
+            'pipelinewise-',
+            ''
+        ) = plugin_use_3m.plugin_name
 
 )
 


### PR DESCRIPTION
Ignore the `pipelinewise-` prefix when aggregating hub metrics at the plugin level because when Meltano installs pipelinewise-tap-postgres it names it tap-postgres so telemetry data excludes the pipelinewise prefix so we need to ignore it for aggregating usage until we refactor to use variant level data.