### PR TITLE
Opt outs

### DIFF
--- a/data/transform/models/marts/telemetry/base/opt_outs.sql
+++ b/data/transform/models/marts/telemetry/base/opt_outs.sql
@@ -1,0 +1,14 @@
+SELECT
+    context_project.project_uuid AS project_id,
+    MIN(stg_snowplow__events.event_created_at) AS opted_out_at
+FROM {{ ref('event_telemetry_state_change') }}
+LEFT JOIN {{ ref('stg_snowplow__events') }}
+    ON event_telemetry_state_change.event_id = stg_snowplow__events.event_id
+LEFT JOIN {{ ref('context_project') }}
+    ON event_telemetry_state_change.event_id = context_project.event_id
+LEFT JOIN {{ ref('context_environment') }}
+    ON event_telemetry_state_change.event_id = context_environment.event_id
+WHERE event_telemetry_state_change.setting_name = 'send_anonymous_usage_stats'
+    AND event_telemetry_state_change.changed_to = 'false'
+    AND context_project.project_uuid IS NOT NULL
+GROUP BY 1

--- a/data/transform/models/marts/telemetry/base/unstructured_parsing/context_environment.sql
+++ b/data/transform/models/marts/telemetry/base/unstructured_parsing/context_environment.sql
@@ -18,7 +18,7 @@ WITH base AS (
             input => PARSE_JSON(event_unstruct.contexts::VARIANT):data
         ) AS context
     WHERE
-        context.value:schema LIKE 'iglu:com.meltano/environment_context/%'
+        event_unstruct.schema_name LIKE 'iglu:com.meltano/environment_context/%'
         AND event_unstruct.contexts IS NOT NULL
     GROUP BY 1, 2
 

--- a/data/transform/models/marts/telemetry/base/unstructured_parsing/context_environment.sql
+++ b/data/transform/models/marts/telemetry/base/unstructured_parsing/context_environment.sql
@@ -2,7 +2,7 @@ WITH base AS (
 
     SELECT
         event_unstruct.event_id,
-        MAX(context.value:schema) AS schema_name,
+        event_unstruct.schema_name,
         MAX(context.value:data:context_uuid::STRING) AS context_uuid,
         MAX(
             context.value:data:freedesktop_version_id::STRING
@@ -20,7 +20,7 @@ WITH base AS (
     WHERE
         context.value:schema LIKE 'iglu:com.meltano/environment_context/%'
         AND event_unstruct.contexts IS NOT NULL
-    GROUP BY 1
+    GROUP BY 1, 2
 
 )
 

--- a/data/transform/models/marts/telemetry/base/unstructured_parsing/context_environment.sql
+++ b/data/transform/models/marts/telemetry/base/unstructured_parsing/context_environment.sql
@@ -1,0 +1,30 @@
+WITH base AS (
+
+    SELECT
+        event_unstruct.event_id,
+        MAX(context.value:schema) AS schema_name,
+        MAX(context.value:data:context_uuid::STRING) AS context_uuid,
+        MAX(
+            context.value:data:freedesktop_version_id::STRING
+        ) AS freedesktop_version_id,
+        MAX(context.value:data:machine::STRING) AS machine,
+        MAX(context.value:data:meltano_version::STRING) AS meltano_version,
+        MAX(
+            context.value:data:num_cpu_cores_available::STRING
+        ) AS num_cpu_cores_available,
+        MAX(context.value:data:windows_edition::STRING) AS windows_edition
+    FROM {{ ref('event_unstruct') }},
+        LATERAL FLATTEN(
+            input => PARSE_JSON(event_unstruct.contexts::VARIANT):data
+        ) AS context
+    WHERE
+        context.value:schema = 'iglu:com.meltano/environment_context/jsonschema/1-0-0'
+        AND event_unstruct.contexts IS NOT NULL
+    GROUP BY 1
+
+)
+
+SELECT
+    *,
+    SPLIT_PART(schema_name, '/', -1) AS schema_version
+FROM base

--- a/data/transform/models/marts/telemetry/base/unstructured_parsing/context_environment.sql
+++ b/data/transform/models/marts/telemetry/base/unstructured_parsing/context_environment.sql
@@ -18,7 +18,7 @@ WITH base AS (
             input => PARSE_JSON(event_unstruct.contexts::VARIANT):data
         ) AS context
     WHERE
-        context.value:schema = 'iglu:com.meltano/environment_context/jsonschema/1-0-0'
+        context.value:schema LIKE 'iglu:com.meltano/environment_context/%'
         AND event_unstruct.contexts IS NOT NULL
     GROUP BY 1
 

--- a/data/transform/models/marts/telemetry/base/unstructured_parsing/context_exception.sql
+++ b/data/transform/models/marts/telemetry/base/unstructured_parsing/context_exception.sql
@@ -10,7 +10,7 @@ WITH base AS (
             input => PARSE_JSON(event_unstruct.contexts::VARIANT):data
         ) AS context
     WHERE
-        context.value:schema LIKE 'iglu:com.meltano/exception_context/%'
+        event_unstruct.schema_name LIKE 'iglu:com.meltano/exception_context/%'
         AND event_unstruct.contexts IS NOT NULL
     GROUP BY 1, 2
 

--- a/data/transform/models/marts/telemetry/base/unstructured_parsing/context_exception.sql
+++ b/data/transform/models/marts/telemetry/base/unstructured_parsing/context_exception.sql
@@ -10,7 +10,7 @@ WITH base AS (
             input => PARSE_JSON(event_unstruct.contexts::VARIANT):data
         ) AS context
     WHERE
-        context.value:schema = 'iglu:com.meltano/exception_context/jsonschema/1-0-0'
+        context.value:schema LIKE 'iglu:com.meltano/exception_context/%'
         AND event_unstruct.contexts IS NOT NULL
     GROUP BY 1
 

--- a/data/transform/models/marts/telemetry/base/unstructured_parsing/context_exception.sql
+++ b/data/transform/models/marts/telemetry/base/unstructured_parsing/context_exception.sql
@@ -2,7 +2,7 @@ WITH base AS (
 
     SELECT
         event_unstruct.event_id,
-        MAX(context.value:schema) AS schema_name,
+        event_unstruct.schema_name,
         MAX(context.value:data:context_uuid::STRING) AS context_uuid,
         MAX(context.value:data:exception::STRING) AS exception
     FROM {{ ref('event_unstruct') }},
@@ -12,7 +12,7 @@ WITH base AS (
     WHERE
         context.value:schema LIKE 'iglu:com.meltano/exception_context/%'
         AND event_unstruct.contexts IS NOT NULL
-    GROUP BY 1
+    GROUP BY 1, 2
 
 )
 

--- a/data/transform/models/marts/telemetry/base/unstructured_parsing/context_exception.sql
+++ b/data/transform/models/marts/telemetry/base/unstructured_parsing/context_exception.sql
@@ -1,0 +1,22 @@
+WITH base AS (
+
+    SELECT
+        event_unstruct.event_id,
+        MAX(context.value:schema) AS schema_name,
+        MAX(context.value:data:context_uuid::STRING) AS context_uuid,
+        MAX(context.value:data:exception::STRING) AS exception
+    FROM {{ ref('event_unstruct') }},
+        LATERAL FLATTEN(
+            input => PARSE_JSON(event_unstruct.contexts::VARIANT):data
+        ) AS context
+    WHERE
+        context.value:schema = 'iglu:com.meltano/exception_context/jsonschema/1-0-0'
+        AND event_unstruct.contexts IS NOT NULL
+    GROUP BY 1
+
+)
+
+SELECT
+    *,
+    SPLIT_PART(schema_name, '/', -1) AS schema_version
+FROM base

--- a/data/transform/models/marts/telemetry/base/unstructured_parsing/context_project.sql
+++ b/data/transform/models/marts/telemetry/base/unstructured_parsing/context_project.sql
@@ -2,7 +2,7 @@ WITH base AS (
 
     SELECT
         event_unstruct.event_id,
-        MAX(context.value:schema) AS schema_name,
+        event_unstruct.schema_name,
         MAX(context.value:data:context_uuid::STRING) AS context_uuid,
         MAX(context.value:data:project_uuid::STRING) AS project_uuid,
         MAX(
@@ -19,7 +19,7 @@ WITH base AS (
     WHERE
         context.value:schema LIKE 'iglu:com.meltano/project_context/%'
         AND event_unstruct.contexts IS NOT NULL
-    GROUP BY 1
+    GROUP BY 1, 2
 
 )
 

--- a/data/transform/models/marts/telemetry/base/unstructured_parsing/context_project.sql
+++ b/data/transform/models/marts/telemetry/base/unstructured_parsing/context_project.sql
@@ -17,7 +17,7 @@ WITH base AS (
             input => PARSE_JSON(event_unstruct.contexts::VARIANT):data
         ) AS context
     WHERE
-        context.value:schema LIKE 'iglu:com.meltano/project_context/%'
+        event_unstruct.schema_name LIKE 'iglu:com.meltano/project_context/%'
         AND event_unstruct.contexts IS NOT NULL
     GROUP BY 1, 2
 

--- a/data/transform/models/marts/telemetry/base/unstructured_parsing/context_project.sql
+++ b/data/transform/models/marts/telemetry/base/unstructured_parsing/context_project.sql
@@ -1,0 +1,29 @@
+WITH base AS (
+
+    SELECT
+        event_unstruct.event_id,
+        MAX(context.value:schema) AS schema_name,
+        MAX(context.value:data:context_uuid::STRING) AS context_uuid,
+        MAX(context.value:data:project_uuid::STRING) AS project_uuid,
+        MAX(
+            context.value:data:project_uuid_source::STRING
+        ) AS project_uuid_source,
+        MAX(
+            context.value:data:environment_name_hash::STRING
+        ) AS environment_name_hash,
+        MAX(context.value:data:client_uuid::STRING) AS client_uuid
+    FROM {{ ref('event_unstruct') }},
+        LATERAL FLATTEN(
+            input => PARSE_JSON(event_unstruct.contexts::VARIANT):data
+        ) AS context
+    WHERE
+        context.value:schema = 'iglu:com.meltano/project_context/jsonschema/1-0-0'
+        AND event_unstruct.contexts IS NOT NULL
+    GROUP BY 1
+
+)
+
+SELECT
+    *,
+    SPLIT_PART(schema_name, '/', -1) AS schema_version
+FROM base

--- a/data/transform/models/marts/telemetry/base/unstructured_parsing/context_project.sql
+++ b/data/transform/models/marts/telemetry/base/unstructured_parsing/context_project.sql
@@ -17,7 +17,7 @@ WITH base AS (
             input => PARSE_JSON(event_unstruct.contexts::VARIANT):data
         ) AS context
     WHERE
-        context.value:schema = 'iglu:com.meltano/project_context/jsonschema/1-0-0'
+        context.value:schema LIKE 'iglu:com.meltano/project_context/%'
         AND event_unstruct.contexts IS NOT NULL
     GROUP BY 1
 

--- a/data/transform/models/marts/telemetry/base/unstructured_parsing/event_telemetry_state_change.sql
+++ b/data/transform/models/marts/telemetry/base/unstructured_parsing/event_telemetry_state_change.sql
@@ -1,0 +1,26 @@
+WITH base AS (
+
+    SELECT
+        event_id,
+        PARSE_JSON(
+            unstruct_event::VARIANT
+        ):data:schema::STRING AS schema_name,
+        PARSE_JSON(
+            unstruct_event::VARIANT
+        ):data:data:changed_from::STRING AS changed_from,
+        PARSE_JSON(
+            unstruct_event::VARIANT
+        ):data:data:changed_to::STRING AS changed_to,
+        PARSE_JSON(
+            unstruct_event::VARIANT
+        ):data:data:setting_name::STRING AS setting_name
+    FROM {{ ref('event_unstruct') }}
+    WHERE
+        event_name = 'telemetry_state_change_event'
+
+)
+
+SELECT
+    *,
+    SPLIT_PART(schema_name, '/', -1) AS schema_version
+FROM base

--- a/data/transform/models/marts/telemetry/base/unstructured_parsing/event_unstruct.sql
+++ b/data/transform/models/marts/telemetry/base/unstructured_parsing/event_unstruct.sql
@@ -1,0 +1,22 @@
+WITH base AS (
+
+    SELECT
+        event_id,
+        event_name,
+        unstruct_event,
+        contexts,
+        PARSE_JSON(
+            unstruct_event::VARIANT
+        ):schema AS schema_name,
+        PARSE_JSON(
+            unstruct_event::VARIANT
+        ):data AS event_data
+    FROM {{ ref('stg_snowplow__events') }}
+    WHERE event = 'unstruct'
+
+)
+
+SELECT
+    *,
+    SPLIT_PART(schema_name, '/', -1) AS schema_version
+FROM base

--- a/data/transform/models/marts/telemetry/base/unstructured_parsing/schema.yml
+++ b/data/transform/models/marts/telemetry/base/unstructured_parsing/schema.yml
@@ -52,3 +52,84 @@ models:
       - name: project_id
         tests:
           - not_null
+
+  - name: event_unstruct
+    description: Snowplow project contexts parsed.
+    columns:
+      - name: event_id
+        tests:
+          - not_null
+          - unique
+      - name: schema_version
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['1-0-0']
+
+  - name: context_project
+    description: Snowplow project contexts parsed.
+    columns:
+      - name: event_id
+        tests:
+          - not_null
+          - unique
+      - name: schema_version
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['1-0-0']
+
+  - name: context_environment
+    description: Snowplow environment contexts parsed.
+    columns:
+      - name: event_id
+        tests:
+          - not_null
+          - unique
+      - name: schema_version
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['1-0-0']
+
+  - name: context_exception
+    description: Snowplow exception contexts parsed.
+    columns:
+      - name: event_id
+        tests:
+          - not_null
+          - unique
+      - name: schema_version
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['1-0-0']
+
+  - name: event_telemetry_state_change
+    description: Snowplow telemetry_state_change event parsed.
+    columns:
+      - name: event_id
+        tests:
+          - not_null
+          - unique
+      - name: schema_version
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['1-0-0']
+      - name: setting_name
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['project_id', 'send_anonymous_usage_stats']
+
+  - name: opt_outs
+    description: Projects that sent an opt out event.
+    columns:
+      - name: project_id
+        tests:
+          - not_null
+          - unique
+      - name: opted_out_at
+        tests:
+          - not_null


### PR DESCRIPTION
Closes https://github.com/meltano/squared/issues/272

- Creates a mapping table of projects and when they opted out
- Starts the process of processing the unstructured events and contexts individually which allows us to handle schema version changes and asserts the schema versions were getting so we dont get unexpected output due to invalid event parsing from new structures.
- We will now get failing tests if new schema versions show up