### PR TITLE
Hub plugin definitions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
     environment: test
     strategy:
       matrix:
-        extract-source: ['slack', 'google_analytics', 'gitlab', 'github_meltano', 'github_search']
+        extract-source: ['slack', 'google_analytics', 'gitlab', 'github_meltano', 'github_search', 'meltanohub']
         # Excluding until mappers are supported using jobs https://github.com/meltano/squared/issues/289
         # , 'spreadsheets_anywhere']
     env:

--- a/data/extract/extractors.meltano.yml
+++ b/data/extract/extractors.meltano.yml
@@ -1,5 +1,21 @@
 plugins:
   extractors:
+  - name: tap-meltanohub
+    namespace: tap_meltanohub
+    pip_url: git+https://github.com/pnadolny13/tap-meltanohub.git
+    executable: tap-meltanohub
+    capabilities:
+    - catalog
+    - state
+    - discover
+    - about
+    - stream-maps
+    settings:
+      - name: api_url
+        label: API URL
+        description: The url for the MeltanoHub API service.
+    select:
+    - plugins.*
   - name: tap-spreadsheets-anywhere
     variant: ets
     pip_url: git+https://github.com/ets/tap-spreadsheets-anywhere.git

--- a/data/orchestrate/dag_definition.yml
+++ b/data/orchestrate/dag_definition.yml
@@ -139,3 +139,19 @@ dags:
         retries: 2
         depends_on:
           - dbt_spreadsheets_anywhere_run_models
+  meltanohub:
+    interval: '0 6 * * *'
+    steps:
+      - name: tap_meltanohub_target_snowflake
+        cmd: 'TARGET_SNOWFLAKE_DEFAULT_TARGET_SCHEMA=MELTANOHUB meltano run tap-meltanohub target-snowflake'
+        retries: 2
+      - name: dbt_meltanohub_run_models
+        cmd: 'meltano invoke dbt-snowflake:run --models staging.meltanohub.*'
+        retries: 2
+        depends_on:
+          - tap_meltanohub_target_snowflake
+      - name: dbt_meltanohub_test_models
+        cmd: 'meltano invoke dbt-snowflake:test --models staging.meltanohub.*'
+        retries: 2
+        depends_on:
+          - dbt_meltanohub_run_models

--- a/data/transform/dbt_project.yml
+++ b/data/transform/dbt_project.yml
@@ -43,6 +43,8 @@ models:
         +schema: gitlab
       github_meltano:
         +schema: github_meltano
+      meltanohub:
+        +schema: meltanohub
       slack:
         +schema: slack
       snowplow:

--- a/data/transform/models/staging/meltanohub/schema.yml
+++ b/data/transform/models/staging/meltanohub/schema.yml
@@ -1,0 +1,9 @@
+version: 2
+
+models:
+  - name: stg_meltanohub__plugins
+    columns:
+      - name: id
+        tests:
+          - unique
+          - not_null

--- a/data/transform/models/staging/meltanohub/sources.yml
+++ b/data/transform/models/staging/meltanohub/sources.yml
@@ -1,0 +1,8 @@
+config-version: 2
+version: 2
+sources:
+  - name: tap_meltanohub
+    database: '{{ env_var("DBT_SNOWFLAKE_DATABASE_RAW") }}'
+    schema: '{{ env_var("DBT_SNOWFLAKE_SOURCE_SCHEMA_PREFIX", "") }}MELTANOHUB'
+    tables:
+      - name: plugins

--- a/data/transform/models/staging/meltanohub/stg_meltanohub__plugins.sql
+++ b/data/transform/models/staging/meltanohub/stg_meltanohub__plugins.sql
@@ -1,0 +1,47 @@
+WITH source AS (
+
+    SELECT
+        *,
+        ROW_NUMBER() OVER (
+            PARTITION BY
+                id
+            ORDER BY _sdc_batched_at DESC
+        ) AS row_num
+    FROM {{ source('tap_meltanohub', 'plugins') }}
+
+),
+
+renamed AS (
+
+    SELECT
+        _sdc_batched_at AS updated_at,
+        capabilities,
+        "DEFAULT" AS is_default, --noqa: L059
+        description,
+        dialect,
+        docs,
+        executable,
+        hidden AS is_hidden,
+        id,
+        label,
+        logo_url,
+        metadata,
+        name,
+        namespace,
+        pip_url,
+        plugin_type,
+        repo,
+        "SELECT" AS select_extra,
+        settings,
+        settings_group_validation,
+        target_schema,
+        "UPDATE" AS update_extra,
+        variant
+    FROM source
+    WHERE row_num = 1
+
+)
+
+SELECT
+    *
+FROM renamed


### PR DESCRIPTION
Closes https://github.com/meltano/squared/issues/275

- adds tap-meltanohub from https://github.com/pnadolny13/tap-meltanohub but forks from https://github.com/AutoIDM/tap-meltanohub so I might end up using the AutoIDM version if the changes get merged.
- adds CI tests for new tap
- airflow dag schedule
- dbt staging logic
