### PR TITLE
Use hub definitions

### DIFF
--- a/data/transform/models/marts/telemetry/base/environments.sql
+++ b/data/transform/models/marts/telemetry/base/environments.sql
@@ -11,3 +11,4 @@ LEFT JOIN
         structured_executions.command = cmd_parsed_all.command
 LEFT JOIN {{ ref('hash_lookup') }}
     ON cmd_parsed_all.environment = hash_lookup.hash_value
+        AND hash_lookup.category = 'environment'

--- a/data/transform/models/marts/telemetry/base/hash_lookup.sql
+++ b/data/transform/models/marts/telemetry/base/hash_lookup.sql
@@ -1,14 +1,56 @@
 WITH base AS (
-    SELECT DISTINCT
-        plugin_name AS unhashed_value,
-        SHA2_HEX(plugin_name) AS hash_value
-    FROM {{ ref('struct_plugins') }}
 
-    UNION
+    SELECT DISTINCT
+        name AS unhashed_value,
+        SHA2_HEX(name) AS hash_value,
+        'plugin_name' AS category
+    FROM {{ ref('stg_meltanohub__plugins') }}
+
+    UNION ALL
+
+    SELECT DISTINCT
+        namespace AS unhashed_value,
+        SHA2_HEX(namespace) AS hash_value,
+        'plugin_namespace' AS category
+    FROM {{ ref('stg_meltanohub__plugins') }}
+
+    UNION ALL
+
+    SELECT DISTINCT
+        executable AS unhashed_value,
+        SHA2_HEX(executable) AS hash_value,
+        'plugin_executable' AS category
+    FROM {{ ref('stg_meltanohub__plugins') }}
+
+    UNION ALL
+
+    SELECT DISTINCT
+        pip_url AS unhashed_value,
+        SHA2_HEX(pip_url) AS hash_value,
+        'plugin_pip_url' AS category
+    FROM {{ ref('stg_meltanohub__plugins') }}
+
+    UNION ALL
+
+    SELECT DISTINCT
+        variant AS unhashed_value,
+        SHA2_HEX(variant) AS hash_value,
+        'plugin_variant' AS category
+    FROM {{ ref('stg_meltanohub__plugins') }}
+
+    UNION ALL
+
+    SELECT
+        'original' AS unhashed_value,
+        SHA2_HEX('original') AS hash_value,
+        'plugin_variant' AS category
+
+    UNION ALL
 
     SELECT
         f.value::STRING AS unhashed_value,
-        SHA2_HEX(f.value) AS hash_value
+        SHA2_HEX(f.value) AS hash_value,
+        'environment' AS category
     FROM
         TABLE(
             FLATTEN(
@@ -19,28 +61,10 @@ WITH base AS (
             )
         ) AS f
 
-    UNION
-
-    SELECT
-        f.value::STRING AS unhashed_value,
-        SHA2_HEX(f.value) AS hash_value
-    FROM
-        TABLE(
-            FLATTEN(
-                input => PARSE_JSON(
-                    '["apache", "singer-io", "transferwise", "meltano", \
-                    "meltanolabs", "bytecodeio", "fishtown-analytics", \
-                    "Mashey", "hotgluexyz", "Matatika", "Pathlight", \
-                    "dbt-labs", "sqlfluff", "great-expectations", "dataops-tk", \
-                    "anelendata", "AutoIDM", "datateer", "adswerve", \
-                    "coeff", "shrutikaponde-vc", "datadotworld", "andyh1203", \
-                    "prontopro", "estrategiahq"]'
-                )
-            )
-        ) AS f
 )
 
 SELECT DISTINCT
     unhashed_value,
-    hash_value
+    hash_value,
+    category
 FROM base

--- a/data/transform/models/marts/telemetry/base/hash_lookup.sql
+++ b/data/transform/models/marts/telemetry/base/hash_lookup.sql
@@ -21,6 +21,7 @@ WITH base AS (
         SHA2_HEX(executable) AS hash_value,
         'plugin_executable' AS category
     FROM {{ ref('stg_meltanohub__plugins') }}
+    WHERE executable IS NOT NULL
 
     UNION ALL
 
@@ -73,7 +74,10 @@ WITH base AS (
 
 )
 
-SELECT DISTINCT
+SELECT
+    {{ dbt_utils.surrogate_key(
+        ['hash_value', 'category']
+    ) }} AS hash_value_id,
     unhashed_value,
     hash_value,
     category

--- a/data/transform/models/marts/telemetry/base/hash_lookup.sql
+++ b/data/transform/models/marts/telemetry/base/hash_lookup.sql
@@ -47,6 +47,16 @@ WITH base AS (
 
     UNION ALL
 
+    SELECT DISTINCT
+        command.value::STRING AS unhashed_value,
+        SHA2_HEX(command.value::STRING) AS hash_value,
+        'plugin_command' AS category
+    FROM {{ ref('stg_meltanohub__plugins') }},
+        LATERAL FLATTEN(input=>OBJECT_KEYS(commands)) AS command
+    WHERE stg_meltanohub__plugins.commands IS NOT NULL
+
+    UNION ALL
+
     SELECT
         f.value::STRING AS unhashed_value,
         SHA2_HEX(f.value) AS hash_value,

--- a/data/transform/models/marts/telemetry/base/plugin_executions.sql
+++ b/data/transform/models/marts/telemetry/base/plugin_executions.sql
@@ -52,6 +52,7 @@ SELECT
 FROM {{ ref('unstruct_plugin_executions') }}
 LEFT JOIN {{ ref('hash_lookup') }}
     ON unstruct_plugin_executions.env_id = hash_lookup.hash_value
+        AND hash_lookup.category = 'environment'
 
 UNION ALL
 
@@ -67,13 +68,13 @@ SELECT
     struct_plugin_executions.command_category,
     -- plugins
     struct_plugin_executions.plugin_name,
-    NULL AS parent_name,
-    NULL AS executable,
-    NULL AS namespace,
-    NULL AS pip_url,
-    NULL AS plugin_variant,
-    NULL AS plugin_command,
-    NULL AS plugin_type, -- extractor/loader/etc.
+    struct_plugin_executions.parent_name,
+    struct_plugin_executions.executable,
+    struct_plugin_executions.namespace,
+    struct_plugin_executions.pip_url,
+    struct_plugin_executions.plugin_variant,
+    struct_plugin_executions.plugin_command,
+    struct_plugin_executions.plugin_type, -- extractor/loader/etc.
     struct_plugin_executions.plugin_category,
     NULL AS plugin_surrogate_key,
     -- projects
@@ -109,3 +110,4 @@ SELECT
 FROM {{ ref('struct_plugin_executions') }}
 LEFT JOIN {{ ref('hash_lookup') }}
     ON struct_plugin_executions.env_id = hash_lookup.hash_value
+        AND hash_lookup.category = 'environment'

--- a/data/transform/models/marts/telemetry/base/schema.yml
+++ b/data/transform/models/marts/telemetry/base/schema.yml
@@ -50,8 +50,10 @@ models:
       - name: hash_value
         tests:
           - not_null
-          - unique
       - name: unhashed_value
+        tests:
+          - not_null
+      - name: hash_value_id
         tests:
           - not_null
           - unique

--- a/data/transform/models/marts/telemetry/base/structured_parsing/struct_plugin_executions.sql
+++ b/data/transform/models/marts/telemetry/base/structured_parsing/struct_plugin_executions.sql
@@ -6,6 +6,8 @@ SELECT
     {{ dbt_utils.surrogate_key(
         [
             'struct_plugins.plugin_name',
+            'struct_plugins.plugin_command',
+            'struct_plugins.plugin_type',
             'structured_executions.execution_id'
         ]
     ) }} AS struct_plugin_exec_pk,

--- a/data/transform/models/marts/telemetry/base/structured_parsing/struct_plugin_executions.sql
+++ b/data/transform/models/marts/telemetry/base/structured_parsing/struct_plugin_executions.sql
@@ -18,6 +18,13 @@ SELECT
     cmd_parsed_all.command_category,
     -- plugins
     struct_plugins.plugin_name AS plugin_name,
+    'UNKNOWN' AS parent_name,
+    'UNKNOWN' AS executable,
+    'UNKNOWN' AS namespace,
+    'UNKNOWN' AS pip_url,
+    'UNKNOWN' AS plugin_variant,
+    struct_plugins.plugin_command,
+    struct_plugins.plugin_type,
     struct_plugins.plugin_category,
     structured_executions.project_id,
     cmd_parsed_all.environment AS env_id

--- a/data/transform/models/marts/telemetry/base/structured_parsing/struct_plugins.sql
+++ b/data/transform/models/marts/telemetry/base/structured_parsing/struct_plugins.sql
@@ -58,10 +58,13 @@ UNION ALL
 
 SELECT DISTINCT
     COALESCE(
-        hash_lookup.unhashed_value,
+        h1.unhashed_value,
         SHA2_HEX(base_other.plugin_name)
     ) AS plugin_name,
-    base_other.command,
+    COALESCE(
+        h2.unhashed_value,
+        SHA2_HEX(base_other.command)
+    ) AS command,
     CASE
         WHEN base_other.plugin_name LIKE 'dbt-%' THEN 'dbt'
         ELSE COALESCE(stg_meltanohub__plugins.name, 'UNKNOWN')
@@ -70,10 +73,13 @@ SELECT DISTINCT
     COALESCE(stg_meltanohub__plugins.plugin_type, 'UNKNOWN') AS plugin_type,
     SPLIT_PART(base_other.plugin_name, ':', 2) AS plugin_command
 FROM base_other
-LEFT JOIN {{ ref('hash_lookup') }}
+LEFT JOIN {{ ref('hash_lookup') }} AS h1
     ON SHA2_HEX(
         SPLIT_PART(base_other.plugin_name, ':', 1)
-    ) = hash_lookup.hash_value
-    AND hash_lookup.category = 'plugin_name'
+    ) = h1.hash_value
+    AND h1.category = 'plugin_name'
+LEFT JOIN {{ ref('hash_lookup') }} AS h2
+    ON SHA2_HEX(base_other.command) = h2.hash_value
+        AND h2.category = 'plugin_command'
 LEFT JOIN {{ ref('stg_meltanohub__plugins') }}
     ON SPLIT_PART(base_other.plugin_name, ':', 1) = stg_meltanohub__plugins.name

--- a/data/transform/models/marts/telemetry/base/structured_parsing/struct_plugins.sql
+++ b/data/transform/models/marts/telemetry/base/structured_parsing/struct_plugins.sql
@@ -1,23 +1,60 @@
+WITH base_singer AS (
+    SELECT
+        flat.value::STRING AS plugin_name,
+        cmd_parsed_all.command
+    FROM {{ ref('cmd_parsed_all') }},
+        LATERAL FLATTEN(input=>singer_plugins) AS flat
+    WHERE cmd_parsed_all.command_type = 'plugin'
+),
+
+base_other AS (
+    SELECT
+        flat.value::STRING AS plugin_name,
+        cmd_parsed_all.command
+    FROM {{ ref('cmd_parsed_all') }},
+        LATERAL FLATTEN(input=>other_plugins) AS flat
+    WHERE cmd_parsed_all.command_type = 'plugin'
+)
+
 SELECT DISTINCT
-    flat.value::STRING AS plugin_name,
-    cmd_parsed_all.command,
-    'singer' AS plugin_category
-FROM {{ ref('cmd_parsed_all') }},
-    LATERAL FLATTEN(input=>singer_plugins) AS flat
-WHERE cmd_parsed_all.command_type = 'plugin'
+    COALESCE(
+        hash_lookup.unhashed_value,
+        SHA2_HEX(base_singer.plugin_name)
+    ) AS plugin_name,
+    base_singer.command,
+    'singer' AS plugin_category,
+    COALESCE(stg_meltanohub__plugins.plugin_type, 'UNKNOWN') AS plugin_type,
+    NULL AS plugin_command
+FROM base_singer
+LEFT JOIN {{ ref('hash_lookup') }}
+    ON SHA2_HEX(base_singer.plugin_name) = hash_lookup.hash_value
+        AND hash_lookup.category = 'plugin_name'
+LEFT JOIN {{ ref('stg_meltanohub__plugins') }}
+    ON base_singer.plugin_name = stg_meltanohub__plugins.name
+
 -- Mappers are included in the singer_plugins list
 
 UNION ALL
 
 SELECT DISTINCT
-    flat.value::STRING AS plugin_name,
-    cmd_parsed_all.command,
+    COALESCE(
+        hash_lookup.unhashed_value,
+        SHA2_HEX(base_other.plugin_name)
+    ) AS plugin_name,
+    base_other.command,
     CASE
-        WHEN flat.value::STRING LIKE 'dbt-%' THEN 'dbt'
+        WHEN base_other.plugin_name LIKE 'dbt-%' THEN 'dbt'
         ELSE
-            SPLIT_PART(flat.value::STRING, ':', 1)
+            SPLIT_PART(base_other.plugin_name, ':', 1)
     END
-    AS plugin_category
-FROM {{ ref('cmd_parsed_all') }},
-    LATERAL FLATTEN(input=>other_plugins) AS flat
-WHERE cmd_parsed_all.command_type = 'plugin'
+    AS plugin_category,
+    COALESCE(stg_meltanohub__plugins.plugin_type, 'UNKNOWN') AS plugin_type,
+    SPLIT_PART(base_other.plugin_name, ':', 2) AS plugin_command
+FROM base_other
+LEFT JOIN {{ ref('hash_lookup') }}
+    ON SHA2_HEX(
+        SPLIT_PART(base_other.plugin_name, ':', 1)
+    ) = hash_lookup.hash_value
+    AND hash_lookup.category = 'plugin_name'
+LEFT JOIN {{ ref('stg_meltanohub__plugins') }}
+    ON SPLIT_PART(base_other.plugin_name, ':', 1) = stg_meltanohub__plugins.name

--- a/data/transform/models/marts/telemetry/base/unstructured_parsing/unstruct_plugins.sql
+++ b/data/transform/models/marts/telemetry/base/unstructured_parsing/unstruct_plugins.sql
@@ -1,7 +1,6 @@
 WITH base AS (
     SELECT
         unstruct_plugins_base.plugin_surrogate_key,
-        unstruct_plugins_base.command,
         unstruct_plugins_base.category AS plugin_type,
         COALESCE(
             h1.unhashed_value, unstruct_plugins_base.name_hash
@@ -20,7 +19,10 @@ WITH base AS (
         ) AS pip_url,
         COALESCE(
             h6.unhashed_value, unstruct_plugins_base.variant_name_hash
-        ) AS variant_name
+        ) AS variant_name,
+        COALESCE(
+            h7.unhashed_value, SHA2_HEX(unstruct_plugins_base.command)
+        ) AS command
     FROM {{ ref('unstruct_plugins_base') }}
     LEFT JOIN {{ ref('hash_lookup') }} AS h1
         ON unstruct_plugins_base.name_hash = h1.hash_value
@@ -40,6 +42,9 @@ WITH base AS (
     LEFT JOIN {{ ref('hash_lookup') }} AS h6
         ON unstruct_plugins_base.variant_name_hash = h6.hash_value
             AND h6.category = 'plugin_variant'
+    LEFT JOIN {{ ref('hash_lookup') }} AS h7
+        ON SHA2_HEX(unstruct_plugins_base.command) = h7.hash_value
+            AND h7.category = 'plugin_command'
 )
 
 SELECT

--- a/data/transform/models/marts/telemetry/base/unstructured_parsing/unstruct_plugins.sql
+++ b/data/transform/models/marts/telemetry/base/unstructured_parsing/unstruct_plugins.sql
@@ -3,25 +3,43 @@ WITH base AS (
         unstruct_plugins_base.plugin_surrogate_key,
         unstruct_plugins_base.command,
         unstruct_plugins_base.category AS plugin_type,
-        h1.unhashed_value AS plugin_name,
-        h2.unhashed_value AS parent_name,
-        h3.unhashed_value AS executable,
-        h4.unhashed_value AS namespace,
-        h5.unhashed_value AS pip_url,
-        h6.unhashed_value AS variant_name
+        COALESCE(
+            h1.unhashed_value, unstruct_plugins_base.name_hash
+        ) AS plugin_name,
+        COALESCE(
+            h2.unhashed_value, unstruct_plugins_base.parent_name_hash
+        ) AS parent_name,
+        COALESCE(
+            h3.unhashed_value, unstruct_plugins_base.executable_hash
+        ) AS executable,
+        COALESCE(
+            h4.unhashed_value, unstruct_plugins_base.namespace_hash
+        ) AS namespace,
+        COALESCE(
+            h5.unhashed_value, unstruct_plugins_base.pip_url_hash
+        ) AS pip_url,
+        COALESCE(
+            h6.unhashed_value, unstruct_plugins_base.variant_name_hash
+        ) AS variant_name
     FROM {{ ref('unstruct_plugins_base') }}
     LEFT JOIN {{ ref('hash_lookup') }} AS h1
         ON unstruct_plugins_base.name_hash = h1.hash_value
+            AND h1.category = 'plugin_name'
     LEFT JOIN {{ ref('hash_lookup') }} AS h2
         ON unstruct_plugins_base.parent_name_hash = h2.hash_value
+            AND h2.category = 'plugin_name'
     LEFT JOIN {{ ref('hash_lookup') }} AS h3
         ON unstruct_plugins_base.executable_hash = h3.hash_value
+            AND h3.category = 'plugin_executable'
     LEFT JOIN {{ ref('hash_lookup') }} AS h4
         ON unstruct_plugins_base.namespace_hash = h4.hash_value
+            AND h4.category = 'plugin_namespace'
     LEFT JOIN {{ ref('hash_lookup') }} AS h5
         ON unstruct_plugins_base.pip_url_hash = h5.hash_value
+            AND h5.category = 'plugin_pip_url'
     LEFT JOIN {{ ref('hash_lookup') }} AS h6
         ON unstruct_plugins_base.variant_name_hash = h6.hash_value
+            AND h6.category = 'plugin_variant'
 )
 
 SELECT

--- a/data/transform/models/staging/meltanohub/stg_meltanohub__plugins.sql
+++ b/data/transform/models/staging/meltanohub/stg_meltanohub__plugins.sql
@@ -16,6 +16,7 @@ renamed AS (
     SELECT
         _sdc_batched_at AS updated_at,
         capabilities,
+        commands,
         "DEFAULT" AS is_default, --noqa: L059
         description,
         dialect,
@@ -31,6 +32,7 @@ renamed AS (
         pip_url,
         plugin_type,
         repo,
+        requires,
         "SELECT" AS select_extra,
         settings,
         settings_group_validation,


### PR DESCRIPTION
Closes https://github.com/meltano/squared/issues/307

- Use only hub definitions for unhashing and leave custom hashed plugins so we can still analyze the hashed version i.e. how many times was that plugin called, by how many projects, etc.
- For structured events where we get the unhashed text, we now hash it ourselves then only unhash if we have the ability to with our hash lookup table sourced from the hub definitions
- Clean up structured plugin types so singer plugins are labeled extractors/loaders/mappers instead of null. This became more important because if we cant unhash the plugin its very helpful to know that its singer/loader vs singer/extractor otherwise its hard to understand anything about the plugin execution.