### PR TITLE
use a cached schedules file for production

### DIFF
--- a/.github/workflows/prod_deploy.yml
+++ b/.github/workflows/prod_deploy.yml
@@ -20,7 +20,14 @@ jobs:
 
     - name: Check out code
       uses: actions/checkout@v2
-    
+
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.8'
+        cache: 'pip'
+    - run: pip install -r data/requirements.txt
+    - run: cd data && meltano schedule list --format=json > orchestrate/schedules.cache.json
+
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -3,3 +3,4 @@
 .env
 
 /analyze/**/*.pyc
+orchestrate/schedules.cache.json

--- a/data/orchestrate/README.md
+++ b/data/orchestrate/README.md
@@ -6,16 +6,20 @@ Follow the [orchestrate docs](https://docs.meltano.com/guide/orchestration) to g
 ## Squared Implementation Notes
 
 In the production environment we are running Airflow on Kubernetes so we use a custom [KubernetesPodOperator](./plugins/meltano_k8_operator.py) to fan out all of our tasks across the cluster but locally we want to use the [BashOperator](https://airflow.apache.org/docs/apache-airflow/stable/howto/operator/bash.html) as if were running in our terminal.
-We also use a DAG [generator](./dags/generator.py) because want to limit as much DAG writing as possible to avoid duplicate code, maintenance burden, and potential for mistakes.
-DAGs are defined in the dag_definition.yml file (eventually will be pulled into Meltano as part of meltano.yml probably) which is read by the generator to build DAG definitions on the fly.
-The DAG generator is referenced by both the locally configured `userdev` environment and the `prod` environment which is built and deployed using the [deploy module](../../deploy/meltano/).
+
+We also use a slight variation of the default DAG [generator](./dags/meltano.py) to support our production deployment better by doing the following:
+
+- Logic to toggle between the KubernetesPodOperator or BashOperator based on the `OPERATOR_TYPE` Airflow variable. In the `userdev` environment its configured to use the BashOperator locally.
+- Allow reading from a cached version of the `meltano schedule list --format=json` output which is in the [schedules.cache.json](schedules.cache.json) file.
+Locally if this file doesn't exist it will run the Meltano subprocess and dynamically generate DAGs (same as the default behavior) but in production our Airflow container doesn't have Meltano installed so instead of dynamically generating the DAGs it just reads the cached output.
+The cache file is generated [during CI](../../.github/workflows/prod_deploy.yml) when the airflow docker image is being built.
 
 To start up locally, using 3 terminals (or add -D for background), then go to http://0.0.0.0:8080 and login.
 ```bash
-# Webserver
-meltano --environment=userdev invoke airflow webserver
 # Create an admin user for UI login
-meltano --environment=userdev invoke airflow users create --username melty --firstname melty --lastname meltano --role Admin --password melty --email melty@meltano.com
-# Scheduler
-meltano --environment=userdev invoke airflow scheduler
+meltano invoke airflow:create-admin
+# Webserver
+meltano invoke airflow:ui
+# Scheduler (in a separate terminal)
+meltano invoke airflow scheduler
 ```

--- a/data/orchestrate/dags/meltano.py
+++ b/data/orchestrate/dags/meltano.py
@@ -11,8 +11,6 @@ import logging
 import os
 import subprocess
 from collections.abc import Iterable
-import pathlib
-import yaml
 
 from airflow import DAG
 
@@ -42,7 +40,8 @@ DEFAULT_ARGS = {
     "concurrency": 1,
 }
 
-ORCHESTRATE_PATH = pathlib.Path(__file__).resolve().parents[1]
+ORCHESTRATE_PATH = Path(__file__).resolve().parents[1]
+SCHEDULE_CACHE = Path(ORCHESTRATE_PATH).joinpath("schedules.cache.json")
 DEFAULT_TAGS = ["meltano"]
 PROJECT_ROOT = os.getenv("MELTANO_PROJECT_ROOT", os.getcwd())
 MELTANO_BIN = ".meltano/run/bin"
@@ -206,9 +205,9 @@ def _meltano_job_generator(schedules):
 def create_dags():
     """Create DAGs for Meltano schedules."""
 
-    if os.path.join(ORCHESTRATE_PATH, "schedules.cache.json").exists():
+    if SCHEDULE_CACHE.exists():
         # Read cached schedules output if exists
-        with open(os.path.join(ORCHESTRATE_PATH, "schedules.cache.json"), "r") as schedules:
+        with open(SCHEDULE_CACHE, "r") as schedules:
             schedule_export = json.load(schedules)
     else:
         list_result = subprocess.run(

--- a/data/orchestrate/dags/meltano.py
+++ b/data/orchestrate/dags/meltano.py
@@ -11,6 +11,8 @@ import logging
 import os
 import subprocess
 from collections.abc import Iterable
+import pathlib
+import yaml
 
 from airflow import DAG
 
@@ -40,6 +42,7 @@ DEFAULT_ARGS = {
     "concurrency": 1,
 }
 
+ORCHESTRATE_PATH = pathlib.Path(__file__).resolve().parents[1]
 DEFAULT_TAGS = ["meltano"]
 PROJECT_ROOT = os.getenv("MELTANO_PROJECT_ROOT", os.getcwd())
 MELTANO_BIN = ".meltano/run/bin"
@@ -202,14 +205,20 @@ def _meltano_job_generator(schedules):
 
 def create_dags():
     """Create DAGs for Meltano schedules."""
-    list_result = subprocess.run(
-        [MELTANO_BIN, "schedule", "list", "--format=json"],
-        cwd=PROJECT_ROOT,
-        stdout=subprocess.PIPE,
-        universal_newlines=True,
-        check=True,
-    )
-    schedule_export = json.loads(list_result.stdout)
+
+    if os.path.join(ORCHESTRATE_PATH, "schedules.cache.json").exists():
+        # Read cached schedules output if exists
+        with open(os.path.join(ORCHESTRATE_PATH, "schedules.cache.json"), "r") as schedules:
+            schedule_export = json.load(schedules)
+    else:
+        list_result = subprocess.run(
+            [MELTANO_BIN, "schedule", "list", "--format=json"],
+            cwd=PROJECT_ROOT,
+            stdout=subprocess.PIPE,
+            universal_newlines=True,
+            check=True,
+        )
+        schedule_export = json.loads(list_result.stdout)
 
     if schedule_export.get("schedules"):
         logger.info(f"Received meltano v2 style schedule export: {schedule_export}")

--- a/data/transform/models/staging/spreadsheets_anywhere/stg_ssa_aws_ips.sql
+++ b/data/transform/models/staging/spreadsheets_anywhere/stg_ssa_aws_ips.sql
@@ -7,18 +7,7 @@ WITH source AS (
                 ip_prefix
             ORDER BY _sdc_batched_at DESC
         ) AS row_num
-
-    -- TODO: remove this once mappers are
-    -- supported using jobs https://github.com/meltano/squared/issues/289
-    {% if env_var("MELTANO_ENVIRONMENT") == "cicd" %}
-
-        FROM raw.spreadsheets_anywhere.aws_ips
-
-    {% else %}
-
-        FROM {{ source('tap_spreadsheets_anywhere', 'aws_ips') }}
-
-    {% endif %}
+    FROM {{ source('tap_spreadsheets_anywhere', 'aws_ips') }}
 
 ),
 

--- a/data/transform/models/staging/spreadsheets_anywhere/stg_ssa_azure_ips.sql
+++ b/data/transform/models/staging/spreadsheets_anywhere/stg_ssa_azure_ips.sql
@@ -7,18 +7,7 @@ WITH source AS (
                 id
             ORDER BY _sdc_batched_at DESC
         ) AS row_num
-
-    -- TODO: remove this once mappers are
-    -- supported using jobs https://github.com/meltano/squared/issues/289
-    {% if env_var("MELTANO_ENVIRONMENT") == "cicd" %}
-
-        FROM raw.spreadsheets_anywhere.azure_ips
-
-    {% else %}
-
-        FROM {{ source('tap_spreadsheets_anywhere', 'azure_ips') }}
-
-    {% endif %}
+    FROM {{ source('tap_spreadsheets_anywhere', 'azure_ips') }}
 
 ),
 

--- a/data/transform/models/staging/spreadsheets_anywhere/stg_ssa_gcp_ips.sql
+++ b/data/transform/models/staging/spreadsheets_anywhere/stg_ssa_gcp_ips.sql
@@ -7,18 +7,7 @@ WITH source AS (
                 id
             ORDER BY _sdc_batched_at DESC
         ) AS row_num
-
-    -- TODO: remove this once mappers are
-    -- supported using jobs https://github.com/meltano/squared/issues/289
-    {% if env_var("MELTANO_ENVIRONMENT") == "cicd" %}
-
-        FROM raw.spreadsheets_anywhere.gcp_ips
-
-    {% else %}
-
-        FROM {{ source('tap_spreadsheets_anywhere', 'gcp_ips') }}
-
-    {% endif %}
+    FROM {{ source('tap_spreadsheets_anywhere', 'gcp_ips') }}
 
 ),
 


### PR DESCRIPTION
In prod the default airflow dag wasnt working because the airflow containers dont have meltano installed. This fix adds a cache json file with the output of `meltano schedule list --format=json` that gets built during CI and is built into the airflow image. The dag generator is updated to use the file if it exists instead of running a meltano command.