### PR TITLE
handle multiple project id sources for one ID

### DIFF
--- a/data/transform/models/marts/telemetry/project_plugins.sql
+++ b/data/transform/models/marts/telemetry/project_plugins.sql
@@ -23,11 +23,7 @@ WITH plugins AS (
             project_dim.first_event_at::TIMESTAMP,
             cli_executions_base.event_created_at::DATE
         ) >= 7
-        -- TODO: move project_uuid_source upstream to cli_executions_base
-        AND COALESCE(
-            unstructured_executions.project_uuid_source,
-            ''
-        ) != 'random'
+        AND project_dim.project_id_source != 'random'
 
 ),
 


### PR DESCRIPTION
Closes https://github.com/meltano/squared/issues/345

Previously we assumed a project Id would only have one source but in reality a new project is initialized with a random ID then its explicit moving forward. We now handle that scenario and skip init when finding the project ID source. The first source is taken, ignoring the init source.