### PR TITLE
fix ip address join to not duplicate

### DIFF
--- a/data/extract/extractors.meltano.yml
+++ b/data/extract/extractors.meltano.yml
@@ -40,7 +40,7 @@ plugins:
           start_date: "2020-01-01T00:00:00Z"
           key_properties: [id]
           name: azure_ips
-          pattern: "ServiceTags_Public_20220808.json"
+          pattern: "ServiceTags_Public_20220822.json"
           json_path: "values"
   - name: tap-slack
     variant: meltanolabs

--- a/data/transform/models/marts/telemetry/fact_cli_executions.sql
+++ b/data/transform/models/marts/telemetry/fact_cli_executions.sql
@@ -12,7 +12,7 @@ SELECT
     cli_executions_base.exit_code,
     cli_executions_base.is_ci_environment,
     cli_executions_base.is_exec_event,
-    ip_address_dim.ip_address_hash,
+    cli_executions_base.ip_address_hash,
     ip_address_dim.cloud_provider,
     ip_address_dim.execution_location
 FROM {{ ref('cli_executions_base') }}
@@ -24,5 +24,7 @@ LEFT JOIN {{ ref('date_dim') }}
     ON cli_executions_base.event_date = date_dim.date_day
 LEFT JOIN {{ ref('ip_address_dim') }}
     ON cli_executions_base.ip_address_hash = ip_address_dim.ip_address_hash
-        AND COALESCE(cli_executions_base.event_created_at
-            < ip_address_dim.active_to, TRUE)
+        AND cli_executions_base.event_created_at
+        BETWEEN ip_address_dim.active_from AND COALESCE(
+            ip_address_dim.active_to, CURRENT_TIMESTAMP
+        )


### PR DESCRIPTION
Closes https://github.com/meltano/squared/issues/371

- IP address join was fanning out executions so tests were failing
- use a start and end range, this means less joins match but its more accurate
- I might end up adjusting the activate date in the snapshots to push it back since they start at the beginning of Aug when really those IP were active prior, we just didnt have a snapshot to track them