### PR TITLE
add s3 bucket for squared and pull in manual notification

### DIFF
--- a/data/utilities/snowplow/snowplow_snowcat_snowpipe.sql
+++ b/data/utilities/snowplow/snowplow_snowcat_snowpipe.sql
@@ -298,3 +298,23 @@ COPY INTO raw.snowplow.events FROM (
 ) FILE_FORMAT = (
     FORMAT_NAME = 'RAW.SNOWPLOW.snowplow_tsv'
 ) ON_ERROR = 'CONTINUE';
+
+
+-- Bad Events
+CREATE STAGE RAW.SNOWPLOW.SNOWCAT_S3_STAGE_BAD
+  url = 's3://mirror-sc-data-snowcat.meltano.com/customer-data/meltano/enriched/bad/'
+  storage_integration = S3_SNOWCAT_INT;
+
+CREATE OR REPLACE TABLE RAW.SNOWPLOW.EVENTS_BAD
+(
+    jsontext    VARIANT,
+    uploaded_at TIMESTAMP_NTZ(9) DEFAULT CAST(CURRENT_TIMESTAMP() AS TIMESTAMP_NTZ(9))
+);
+
+CREATE OR REPLACE PIPE raw.snowplow.events_bad_pipe auto_ingest= TRUE AS
+COPY INTO raw.snowplow.EVENTS_BAD (jsontext)
+    FROM @RAW.SNOWPLOW.SNOWCAT_S3_STAGE_BAD
+    FILE_FORMAT = (
+      FORMAT_NAME = 'RAW.SNOWPLOW.snowplow_tsv'
+    )
+ON_ERROR = 'CONTINUE';

--- a/deploy/infrastructure/main.tf
+++ b/deploy/infrastructure/main.tf
@@ -15,7 +15,7 @@ locals {
 }
 
 module "infrastructure" {
-  source = "git::https://gitlab.com/meltano/infra/terraform.git//aws/modules/infrastructure?ref=v0.1.0"
+  source = "git::https://github.com/meltano/terraform-meltano.git//aws/modules/infrastructure?ref=v0.1.0"
   # source = "../../../infrastructure/terraform/aws/modules/infrastructure"
   aws_region = local.aws_region
 }

--- a/deploy/infrastructure/s3.tf
+++ b/deploy/infrastructure/s3.tf
@@ -1,0 +1,11 @@
+resource "aws_s3_bucket" "meltano-squared-prod" {
+  bucket = "meltano-squared-prod"
+  acl    = "private"
+
+  versioning {
+    enabled = true
+  }
+
+  provider = aws.us_west_2
+
+}

--- a/deploy/infrastructure/snowflake.tf
+++ b/deploy/infrastructure/snowflake.tf
@@ -41,4 +41,11 @@ resource "aws_s3_bucket_notification" "bucket_notification" {
     filter_prefix = "customer-data/meltano/enriched/stream/"
     filter_suffix = ".gz"
   }
+
+  queue {
+    queue_arn     = local.snowpipe.snowflake_sqs_arn
+    events        = ["s3:ObjectCreated:*"]
+    filter_prefix = "customer-data/meltano/enriched/bad/"
+    filter_suffix = ".gz"
+  }
 }


### PR DESCRIPTION
Closes https://github.com/meltano/squared/issues/352 https://github.com/meltano/squared/issues/254

None of these additions are automatically deployed.

- Creates a prod S3 bucket for https://github.com/meltano/squared/issues/352 and https://github.com/meltano/squared/issues/247
- I created the snowflake objects manually but wanted to log an artifact.
- The Terraform changes add an additional SQS notification for files dropped into the "bad" prefix. They get picked up by the Snowpipe thats also created in this PR.
- The bad events were time sensitive for QA so I manually added the notification to the bucket because the infrastructure 


@kgpayne Terraform plan was doing some stuff related to EKS while I was trying to apply my changes. Also I'm looking for a little guidance on how to handle S3 policies for this prod bucket.