### PR TITLE
Public slack channels

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,7 @@ jobs:
     environment: test
     strategy:
       matrix:
-        extract-source: ['meltanohub_el', 'spreadsheets_anywhere_el', 'github_search_el', 'github_meltano_el', 'gitlab_el', 'slack_el', 'google_analytics_el', 'snowplow_el']
+        extract-source: ['meltanohub_el', 'spreadsheets_anywhere_el', 'github_search_el', 'github_meltano_el', 'gitlab_el', 'slack_el', 'slack_public_el', 'google_analytics_el', 'snowplow_el']
     env:
       MELTANO_ENVIRONMENT: cicd
       MELTANO_SEND_ANONYMOUS_USAGE_STATS: 'false'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,7 @@ jobs:
     environment: test
     strategy:
       matrix:
-        extract-source: ['meltanohub_el', 'spreadsheets_anywhere_el', 'github_search_el', 'github_meltano_el', 'gitlab_el', 'slack_el', 'slack_public_el', 'google_analytics_el', 'snowplow_el']
+        extract-source: ['meltanohub_el', 'spreadsheets_anywhere_el', 'github_search_el', 'github_meltano_el', 'gitlab_el', 'slack_el', 'google_analytics_el', 'snowplow_el']
     env:
       MELTANO_ENVIRONMENT: cicd
       MELTANO_SEND_ANONYMOUS_USAGE_STATS: 'false'

--- a/data/environments/cicd.meltano.yml
+++ b/data/environments/cicd.meltano.yml
@@ -6,6 +6,9 @@ environments:
       - name: tap-slack
         config:
           start_date: ${DEFAULT_START_DATE}
+      - name: tap-slack-public
+        config:
+          start_date: ${DEFAULT_START_DATE}
       - name: tap-google-analytics
         config:
           start_date: ${DEFAULT_START_DATE}

--- a/data/environments/prod.meltano.yml
+++ b/data/environments/prod.meltano.yml
@@ -3,6 +3,9 @@ environments:
   config:
     plugins:
       extractors:
+      - name: tap-slack-public
+        config:
+          thread_lookback_days: 7
       - name: tap-google-analytics
         config:
           start_date: '2022-02-20'

--- a/data/environments/userdev.meltano.yml
+++ b/data/environments/userdev.meltano.yml
@@ -3,6 +3,9 @@ environments:
   config:
     plugins:
       extractors:
+      - name: tap-slack-public
+        config:
+          start_date: '2022-09-01'
       - name: tap-google-analytics
         config:
           start_date: '2022-02-20'
@@ -61,7 +64,7 @@ environments:
           role: ${USER_PREFIX}
           warehouse: CORE
   env:
-    USER_PREFIX: melty
+    USER_PREFIX: pnadolny
     HUB_METRICS_S3_PATH: s3://devtest-meltano-bucket-01/hub_metrics/
     SUPERSET_API_URL: http://localhost:8088
     SUPERSET_USER: admin

--- a/data/environments/userdev.meltano.yml
+++ b/data/environments/userdev.meltano.yml
@@ -64,7 +64,7 @@ environments:
           role: ${USER_PREFIX}
           warehouse: CORE
   env:
-    USER_PREFIX: pnadolny
+    USER_PREFIX: melty
     HUB_METRICS_S3_PATH: s3://devtest-meltano-bucket-01/hub_metrics/
     SUPERSET_API_URL: http://localhost:8088
     SUPERSET_USER: admin

--- a/data/extract/extractors.meltano.yml
+++ b/data/extract/extractors.meltano.yml
@@ -56,6 +56,20 @@ plugins:
     - users.*
     - channels.*
     - messages.*
+
+  - name: tap-slack-public
+    inherit_from: tap-slack
+    config:
+      start_date: '2021-01-01'
+      auto_join_channels: false
+      thread_lookback_days: 1
+      selected_channels: []
+      channel_types:
+      - public_channel
+    select:
+    - channels.*
+    - messages.*
+    - threads.*
   - name: tap-google-analytics
     variant: meltanolabs
     pip_url: git+https://github.com/MeltanoLabs/tap-google-analytics.git@v0.0.4

--- a/data/orchestrate/orchestrators.meltano.yml
+++ b/data/orchestrate/orchestrators.meltano.yml
@@ -96,7 +96,8 @@ jobs:
 
 - name: slack_el
   tasks:
-  - tap-slack target-snowflake
+  - tap-slack target-snowflake 
+  - tap-slack-public target-snowflake
   - dbt-snowflake:run_staging_slack
   - dbt-snowflake:test_staging_slack
 

--- a/data/transform/models/staging/slack/schema.yml
+++ b/data/transform/models/staging/slack/schema.yml
@@ -7,3 +7,24 @@ models:
         tests:
           - unique
           - not_null
+
+  - name: stg_slack__users
+    columns:
+      - name: user_id
+        tests:
+          - unique
+          - not_null
+
+  - name: stg_slack__channels
+    columns:
+      - name: channel_id
+        tests:
+          - unique
+          - not_null
+
+  - name: stg_slack__threads
+    columns:
+      - name: thread_message_surrogate_key
+        tests:
+          - unique
+          - not_null

--- a/data/transform/models/staging/slack/sources.yml
+++ b/data/transform/models/staging/slack/sources.yml
@@ -7,3 +7,11 @@ sources:
     tables:
       - name: users
       - name: messages
+      - name: channels
+  - name: tap_slack_public
+    database: '{{ env_var("DBT_SNOWFLAKE_DATABASE_RAW") }}'
+    schema: '{{ env_var("DBT_SNOWFLAKE_SOURCE_SCHEMA_PREFIX", "") }}TAP_SLACK_PUBLIC'
+    tables:
+      - name: messages
+      - name: channels
+      - name: threads

--- a/data/transform/models/staging/slack/stg_slack__channels.sql
+++ b/data/transform/models/staging/slack/stg_slack__channels.sql
@@ -24,7 +24,7 @@ renamed AS (
 
     SELECT
         id AS channel_id,
-        creator_user_id,
+        creator AS creator_user_id,
         is_archived,
         is_channel,
         is_ext_shared,

--- a/data/transform/models/staging/slack/stg_slack__channels.sql
+++ b/data/transform/models/staging/slack/stg_slack__channels.sql
@@ -1,0 +1,58 @@
+WITH source AS (
+
+    SELECT
+        *,
+        ROW_NUMBER() OVER (
+            PARTITION BY id
+            ORDER BY _sdc_batched_at DESC
+        ) AS row_num
+    FROM {{ source('tap_slack', 'channels') }}
+
+    UNION ALL
+
+    SELECT
+        *,
+        ROW_NUMBER() OVER (
+            PARTITION BY id
+            ORDER BY _sdc_batched_at DESC
+        ) AS row_num
+    FROM {{ source('tap_slack_public', 'channels') }}
+
+),
+
+renamed AS (
+
+    SELECT
+        id AS channel_id,
+        creator_user_id,
+        is_archived,
+        is_channel,
+        is_ext_shared,
+        is_general,
+        is_group,
+        is_im,
+        is_member,
+        is_mpim,
+        is_org_shared,
+        is_pending_ext_shared,
+        is_private,
+        is_shared,
+        name AS channel_name,
+        name_normalized AS channel_name_normalized,
+        num_members,
+        parent_conversation,
+        pending_connected_team_ids,
+        pending_shared,
+        previous_names,
+        purpose,
+        shared_team_ids,
+        topic,
+        unlinked,
+        TO_TIMESTAMP_NTZ(created::INT) AS created_at
+    FROM source
+    WHERE row_num = 1
+
+)
+
+SELECT *
+FROM renamed

--- a/data/transform/models/staging/slack/stg_slack__messages.sql
+++ b/data/transform/models/staging/slack/stg_slack__messages.sql
@@ -7,6 +7,15 @@ WITH source AS (
         *
     FROM {{ source('tap_slack', 'messages') }}
 
+    UNION ALL
+
+    SELECT
+        {{ dbt_utils.surrogate_key(
+            ['ts', 'client_msg_id', 'user', 'bot_id']
+        ) }} AS message_surrogate_key,
+        *
+    FROM {{ source('tap_slack_public', 'messages') }}
+
 ),
 
 clean_source AS (

--- a/data/transform/models/staging/slack/stg_slack__threads.sql
+++ b/data/transform/models/staging/slack/stg_slack__threads.sql
@@ -17,7 +17,7 @@ clean_source AS (
             PARTITION BY
                 thread_message_surrogate_key
             ORDER BY _sdc_batched_at DESC
-        ) AS row_number
+        ) AS row_num
     FROM source
 
 ),

--- a/data/transform/models/staging/slack/stg_slack__threads.sql
+++ b/data/transform/models/staging/slack/stg_slack__threads.sql
@@ -1,0 +1,55 @@
+WITH source AS (
+
+    SELECT
+        {{ dbt_utils.surrogate_key(
+            ['ts', 'thread_ts', 'client_msg_id', 'user']
+        ) }} AS thread_message_surrogate_key,
+        *
+    FROM {{ source('tap_slack_public', 'threads') }}
+
+),
+
+clean_source AS (
+
+    SELECT
+        *,
+        ROW_NUMBER() OVER (
+            PARTITION BY
+                thread_message_surrogate_key
+            ORDER BY _sdc_batched_at DESC
+        ) AS row_number
+    FROM source
+
+),
+
+renamed AS (
+
+    SELECT
+        thread_message_surrogate_key,
+        channel_id,
+        blocks,
+        client_msg_id,
+        edited,
+        files,
+        is_locked,
+        latest_reply AS latest_reply_id,
+        team,
+        text AS message_content,
+        type AS message_type,
+        upload,
+        user AS user_id,
+        parent_user_id,
+        display_as_bot,
+        reply_count,
+        reply_users,
+        reply_users_count,
+        subscribed,
+        TO_TIMESTAMP_NTZ(ts::INT) AS message_created_at,
+        TO_TIMESTAMP_NTZ(thread_ts::INT) AS thread_ts
+    FROM clean_source
+    WHERE row_num = 1
+
+)
+
+SELECT *
+FROM renamed


### PR DESCRIPTION
closes https://github.com/meltano/squared/issues/395

- The tap only lets you pull private or public channels not a combination so I inherited as 2 different extractors. Leaving the current tap-slack with private messages and a new tap-slack-public for all public channels.
- We dont filter for channels so all are retrieved
- Threads staging came from https://github.com/meltano/squared/pull/377 with the only change being that I added `thread_ts` to the [surrogate key creation](https://github.com/meltano/squared/pull/377/files#diff-00517ca13cdfcf3081d9a76a40043ad51f4ed693b573c028397752c00363cd3bR5). FYI @waynebanksy
- the messages dbt staging model now unions all messages from private and public channels so vs maintaining duplicate staging model logic
- thread look back is set to 7 days for prod and accepts the default for all other envs. This means if after a thread is >7 days old we will stop looking for new messages in it. We may want to expand this but 7 felt fine for now.
- adds schema test for users which wasnt there before
- the public extractor instance doesnt pull users because the data is the same from the existing tap-slack extractor pulling from the private channel. It was 100% duplicate data so I excluded it.
