### PR TITLE
bugfix: remove filter for structured events for snowplow activation date

### DIFF
--- a/data/transform/models/marts/telemetry/base/event_src_activation.md
+++ b/data/transform/models/marts/telemetry/base/event_src_activation.md
@@ -1,0 +1,20 @@
+{% docs event_src_activation %}
+
+Our telemetry events were originally coming from Google Analytics in structured form, then we started using Snowplow continuing to send the same structured events, then we upgraded to send rich unstructured events to Snowplow along with the structured events, then we ultimately turned off the structured events in favor of the unstructured events.
+
+1. Google Analytics structured
+1. Snowplow structured
+1. Snowplow structured and unstructured (>=2.0)
+1. Snowplow unstructured (>=2.5.0)
+
+Since we have these 4 states we need to blend them carefully to preserve history and to transition from one source/structure to the next in an accurate way.
+
+This model does its best to define when Snowplow should be activated as the primary telemetry source for a project.
+The challenge is that we don't want to flip to the new source immediately upon recieving the first event from that source/structure.
+For example some projects will be running in production with GA as the source but they test >2.0 version locally. We still want to consider GA as the primary source until we get more events coming from Snowplow than from GA. This model compares event counts to decide what date we have enough Snowplow events to get full coverage on the project's activity before activating it.
+
+Snowplow receives more events that GA does because the GA only gets successful executions whereas Snowplow gets all executions. So the most accurate way to compare counts is to filter only when we got both an unstructured event and a structured event in parallel. Unfortunately that approach has many limitations: meltano version >=2.5.0 turns off sending parallel structured events, the presence of failure/aborted events means some projects never send a successful structured event but they do send failed/aborted unstructured events, etc.
+
+The decision was to reduce complexity with a small accuracy tradeoff by comparing all Snowplow event counts to GA event counts. Snowplow only receives about 5% more events than GA so its a worth while tradeoff.
+
+{% enddocs %}

--- a/data/transform/models/marts/telemetry/base/event_src_activation.sql
+++ b/data/transform/models/marts/telemetry/base/event_src_activation.sql
@@ -5,8 +5,6 @@ WITH snow_v2 AS (
         DATE_TRUNC('WEEK', started_ts) AS event_week_start_date,
         COUNT(DISTINCT execution_id) AS events
     FROM {{ ref('unstruct_exec_flattened') }}
-    -- TODO: find a better way to do this without needing struct events
-    WHERE struct_project_id IS NOT NULL
     GROUP BY 1, 2
 
 ),
@@ -21,6 +19,7 @@ snow_pre_v2 AS (
         {{ ref('stg_snowplow__events') }}
     WHERE contexts IS NULL
         AND event = 'struct'
+        AND se_label IS NOT NULL
     GROUP BY 1, 2
 
 ),

--- a/data/transform/models/marts/telemetry/base/schema.yml
+++ b/data/transform/models/marts/telemetry/base/schema.yml
@@ -122,4 +122,15 @@ models:
       - name: event_date
         tests:
           - not_null
-          
+
+  - name: event_src_activation
+    description: '{{ doc("event_src_activation") }}'
+    columns:
+      - name: project_id
+        description: The unique plugin execution ID.
+        tests:
+          - not_null
+          - unique
+      - name: sp_activate_date
+        tests:
+          - not_null

--- a/data/transform/tests/marts/telemetry/base/assert_all_unstruct_project_ids_persist.sql
+++ b/data/transform/tests/marts/telemetry/base/assert_all_unstruct_project_ids_persist.sql
@@ -1,0 +1,9 @@
+-- Unstructured project ID either has Snowplow as active source
+-- or its active in GA.
+SELECT project_id FROM {{ ref('unstruct_exec_flattened') }}
+MINUS
+SELECT DISTINCT project_id FROM (
+    SELECT DISTINCT project_id FROM {{ ref('event_src_activation') }}
+    UNION
+    SELECT DISTINCT project_id FROM {{ ref('stg_ga__cli_events') }}
+)

--- a/data/transform/tests/marts/telemetry/base/assert_cli_executions_base_project_ids.sql
+++ b/data/transform/tests/marts/telemetry/base/assert_cli_executions_base_project_ids.sql
@@ -1,0 +1,13 @@
+SELECT project_id
+FROM (
+
+    SELECT DISTINCT project_id FROM {{ ref('unstruct_exec_flattened') }}
+    UNION
+    SELECT DISTINCT project_id FROM {{ ref('stg_ga__cli_events') }}
+
+)
+WHERE project_id NOT IN (
+
+    SELECT DISTINCT project_id FROM {{ ref('cli_executions_base') }}
+
+)


### PR DESCRIPTION
Related to https://github.com/meltano/internal-data/issues/26#issuecomment-1254024339

- Fixes the bug
- Adds tests to assert that all project IDs are making it from the raw tables to the base executions tables
- better docs

I tried to do my best to describe what this model is doing in the [dbt docs](https://github.com/meltano/squared/pull/416/files#diff-e8f1c604a4e7a1d02981177533eb862d3b8d3c876300f98fb8423e092f4aea9d).

The goal was originally to get an apples to apples event count comparison between snowplow and GA, then make a decision whether we're getting enough data in Snowplow to start considering it as the primary telemetry source for that project. This is required because historical metrics wont be preserved unless we blend the sources. A challenge with this is that Snowplow gets more cumulative events than GA because GA only gets successes.

The bug was introduced because I was trying to count apples to apples by using the presence of the redundant structured events that we sent to snowplow along side the new rich unstructured events. This is the most accurate way to compare like to like and it worked for a while but we no longer send those redundant events following https://github.com/meltano/meltano/pull/6622. The result was that any project created for the first time on meltano >=2.5.0 was being filtered out. This didnt affect most projects that existing already and upgraded to >=2.5.0, because we had snowplow activated as their primary source already but a jump from <1.0.5 to >=2.5.0 would have been affected. 

In the process of fixing this I found that it caused another related bug where it was also excluding a very small number of projects that sent a few non-successful/incomplete events, so a structured event never fired.

I tried a bunch of different techniques to fix this bug like filtering based on meltano version, current logic + additional unions to capture the related described above, etc. The simpliest and least error prone ended up being to simply remove the filter completely which makes the comparison marginally less accurate and the extra events we get from snowplow were only a 5%ish extra bump so it was a reasonable trade off. Also we're using a weekly sum of events so being super accurate isnt totally necessary in my opionion.


Affect on the data: most numbers have slight improvements in the last 1.5 months, nothing super notable though. Like pipeline runs got a 1k bump last month to the 1.1M number. This months active added count increased, as expected because we were filtering out some of the newly active projects by accident. 
