### PR TITLE
clean up exec event logic

### DIFF
--- a/data/transform/models/marts/telemetry/base/cli_executions_base.sql
+++ b/data/transform/models/marts/telemetry/base/cli_executions_base.sql
@@ -91,7 +91,6 @@ combined AS (
         NULL AS meltano_version,
         NULL AS python_version,
         NULL AS is_ci_environment,
-        event_commands_parsed.is_exec_event,
         event_commands_parsed.is_legacy_event,
         -- Plugins
         event_commands_parsed.is_plugin_dbt,
@@ -171,21 +170,6 @@ combined AS (
         unstructured_executions.meltano_version,
         unstructured_executions.python_version,
         unstructured_executions.is_ci_environment,
-        COALESCE(
-            unstructured_executions.cli_command IN (
-                'meltano invoke',
-                'meltano elt',
-                'meltano run',
-                'meltano test',
-                'meltano ui',
-                'invoke',
-                'elt',
-                'run',
-                'test',
-                'ui'
-            ),
-            FALSE
-        ) AS is_exec_event,
         COALESCE(unstructured_executions.cli_command IN (
                 'meltano transforms',
                 'meltano dashboards',
@@ -261,7 +245,6 @@ SELECT
     combined.exit_code,
     combined.is_tracking_disabled,
     combined.is_ci_environment,
-    combined.is_exec_event,
     combined.is_legacy_event,
     combined.is_plugin_dbt,
     combined.is_plugin_singer,
@@ -279,6 +262,15 @@ SELECT
     combined.is_acquired_date,
     combined.is_churned_date,
     combined.is_retained_date,
+    COALESCE(
+        combined.cli_command IN (
+            'invoke',
+            'elt',
+            'run',
+            'test'
+        ),
+        FALSE
+    ) AS is_exec_event,
     DATEDIFF(
         MILLISECOND,
         combined.started_ts,

--- a/data/transform/models/marts/telemetry/base/event_commands_parsed.sql
+++ b/data/transform/models/marts/telemetry/base/event_commands_parsed.sql
@@ -9,29 +9,6 @@ WITH unique_commands AS (
 
 ),
 
-exec_event AS (
-
-    SELECT command
-    FROM unique_commands
-    WHERE
-        command_category IN (
-            'meltano invoke',
-            'meltano elt',
-            'meltano ui',
-            'meltano test',
-            'meltano run',
-            'meltano ui'
-        )
-
-    UNION ALL
-
-    SELECT command
-    FROM unique_commands
-    WHERE command_category = 'meltano schedule'
-        AND split_part_3 LIKE 'run%'
-
-),
-
 legacy AS (
 
     SELECT command
@@ -394,7 +371,6 @@ cli_mappers AS (
 SELECT
     unique_commands.command,
     unique_commands.command_category,
-    NOT COALESCE(exec_event.command IS NULL, FALSE) AS is_exec_event,
     NOT COALESCE(legacy.command IS NULL, FALSE) AS is_legacy_event,
     NOT COALESCE(singer.command IS NULL, FALSE) AS is_plugin_singer,
     NOT COALESCE(dbt.command IS NULL, FALSE) AS is_plugin_dbt,
@@ -415,7 +391,6 @@ SELECT
         cli_mappers.command IS NULL, FALSE
     ) AS is_os_feature_mappers
 FROM unique_commands
-LEFT JOIN exec_event ON unique_commands.command = exec_event.command
 LEFT JOIN legacy ON unique_commands.command = legacy.command
 LEFT JOIN singer ON unique_commands.command = singer.command
 LEFT JOIN dbt ON unique_commands.command = dbt.command

--- a/data/transform/models/marts/telemetry/schema.yml
+++ b/data/transform/models/marts/telemetry/schema.yml
@@ -374,7 +374,7 @@ models:
         description: A boolean whether the execution environment had CI env vars present.
 
       - name: is_exec_event
-        description: A boolean whether the execution used a CLI command thats considered a plugin execution.
+        description: A boolean whether the execution used a CLI command thats considered an execution.
 
       - name: ip_address_hash
         description: The hash of the IP address.


### PR DESCRIPTION
The is_exec flag is key to calculating whether a project is active or not. The logic was spread out across struct/unstruct models which is now unnecessary. Clean it up so logic is maintained in 1 place.