### PR TITLE
add eom active status and 1d filter variation to 7d

### DIFF
--- a/data/transform/models/marts/telemetry/base/temp_active_projects_base_1d.sql
+++ b/data/transform/models/marts/telemetry/base/temp_active_projects_base_1d.sql
@@ -1,0 +1,27 @@
+{{
+    config(materialized='table')
+}}
+
+SELECT DISTINCT
+    cli_executions_base.event_created_at::DATE AS date_day,
+    project_base.project_id,
+    CASE
+        WHEN
+            plugin_executions.plugin_category NOT IN (
+                'singer', 'dbt', 'great_expectations', 'superset', 'airflow'
+            ) THEN 'other'
+        ELSE plugin_executions.plugin_category
+    END AS plugin_category
+FROM {{ ref('plugin_executions') }}
+LEFT JOIN {{ ref('cli_executions_base') }}
+    ON plugin_executions.execution_id = cli_executions_base.execution_id
+LEFT JOIN {{ ref('project_base') }}
+    ON cli_executions_base.project_id = project_base.project_id
+WHERE
+    cli_executions_base.is_exec_event
+    AND DATEDIFF(
+        'day',
+        project_base.first_event_at::TIMESTAMP,
+        cli_executions_base.event_created_at::DATE
+    ) >= 1
+    AND project_base.project_id_source != 'random'

--- a/data/transform/models/marts/telemetry/fact_cli_executions.sql
+++ b/data/transform/models/marts/telemetry/fact_cli_executions.sql
@@ -41,6 +41,10 @@ LEFT JOIN {{ ref('ip_address_dim') }}
 LEFT JOIN {{ ref('daily_active_projects') }}
     ON cli_executions_base.project_id = daily_active_projects.project_id
         AND date_dim.date_day = daily_active_projects.date_day
-LEFT JOIN {{ ref('daily_active_projects') }} AS daily_active_projects_eom
+LEFT JOIN {{ ref('daily_active_projects') }}
+    AS daily_active_projects_eom -- noqa: L031
     ON cli_executions_base.project_id = daily_active_projects_eom.project_id
-        AND CASE WHEN date_dim.last_day_of_month <= CURRENT_DATE THEN date_dim.last_day_of_month ELSE date_dim.date_day END = daily_active_projects_eom.date_day
+        AND CASE WHEN date_dim.last_day_of_month <= CURRENT_DATE
+            THEN date_dim.last_day_of_month
+            ELSE date_dim.date_day
+        END = daily_active_projects_eom.date_day

--- a/data/transform/models/marts/telemetry/temp_daily_active_projects_1d.sql
+++ b/data/transform/models/marts/telemetry/temp_daily_active_projects_1d.sql
@@ -3,7 +3,7 @@ WITH base AS (
         project_id,
         date_day AS exec_date,
         COUNT(*) AS exec_count
-    FROM {{ ref('active_projects_base') }}
+    FROM {{ ref('temp_active_projects_base_1d') }}
     GROUP BY 1, 2
 ),
 

--- a/data/transform/models/marts/telemetry/temp_fact_cli_executions_1d.sql
+++ b/data/transform/models/marts/telemetry/temp_fact_cli_executions_1d.sql
@@ -41,6 +41,10 @@ LEFT JOIN {{ ref('ip_address_dim') }}
 LEFT JOIN {{ ref('temp_daily_active_projects_1d') }}
     ON cli_executions_base.project_id = temp_daily_active_projects_1d.project_id
         AND date_dim.date_day = temp_daily_active_projects_1d.date_day
-LEFT JOIN {{ ref('temp_daily_active_projects_1d') }} AS daily_active_projects_eom
+LEFT JOIN {{ ref('temp_daily_active_projects_1d') }}
+    AS daily_active_projects_eom -- noqa: L031
     ON cli_executions_base.project_id = daily_active_projects_eom.project_id
-        AND CASE WHEN date_dim.last_day_of_month <= CURRENT_DATE THEN date_dim.last_day_of_month ELSE date_dim.date_day END = daily_active_projects_eom.date_day
+        AND CASE WHEN date_dim.last_day_of_month <= CURRENT_DATE
+            THEN date_dim.last_day_of_month
+            ELSE date_dim.date_day
+        END = daily_active_projects_eom.date_day

--- a/data/transform/models/marts/telemetry/temp_fact_cli_executions_1d.sql
+++ b/data/transform/models/marts/telemetry/temp_fact_cli_executions_1d.sql
@@ -18,7 +18,7 @@ SELECT
     ip_address_dim.cloud_provider,
     ip_address_dim.execution_location,
     COALESCE(
-        daily_active_projects.project_id IS NOT NULL,
+        temp_daily_active_projects_1d.project_id IS NOT NULL,
         FALSE
     ) AS is_active_cli_execution,
     COALESCE(
@@ -38,9 +38,9 @@ LEFT JOIN {{ ref('ip_address_dim') }}
         BETWEEN ip_address_dim.active_from AND COALESCE(
             ip_address_dim.active_to, CURRENT_TIMESTAMP
         )
-LEFT JOIN {{ ref('daily_active_projects') }}
-    ON cli_executions_base.project_id = daily_active_projects.project_id
-        AND date_dim.date_day = daily_active_projects.date_day
-LEFT JOIN {{ ref('daily_active_projects') }} AS daily_active_projects_eom
+LEFT JOIN {{ ref('temp_daily_active_projects_1d') }}
+    ON cli_executions_base.project_id = temp_daily_active_projects_1d.project_id
+        AND date_dim.date_day = temp_daily_active_projects_1d.date_day
+LEFT JOIN {{ ref('temp_daily_active_projects_1d') }} AS daily_active_projects_eom
     ON cli_executions_base.project_id = daily_active_projects_eom.project_id
         AND CASE WHEN date_dim.last_day_of_month <= CURRENT_DATE THEN date_dim.last_day_of_month ELSE date_dim.date_day END = daily_active_projects_eom.date_day


### PR DESCRIPTION
Related to https://github.com/meltano/squared/issues/407

- Adds end of month active flag. Now we can filter for plain active meaning at the time an execution happened, and active at the end of month (EOM). This allows us to excluded projects that might have run something but have since churned, or the opposite where a project becomes active by the end of the month but their execution was between the exploration period <=7d
- Adds a few temporary tables that are simply used for testing the variation of >=1 day active filtering vs the current >=7 day.

cc @tayloramurphy 