### PR TITLE
Top of funnel filtering

### DIFF
--- a/data/transform/models/marts/telemetry/project_funnel_cohort.sql
+++ b/data/transform/models/marts/telemetry/project_funnel_cohort.sql
@@ -1,17 +1,41 @@
 {% set mapping = {
+    "NOT_RANDOM": {
+        'filter': "project_id_source != 'random'"
+    },
+    "NOT_CI_ONLY": {
+        'parent_name': 'NOT_RANDOM',
+        'filter': "is_ci_only_project = FALSE"
+    },
+    "NOT_NULL_VERSION": {
+        'parent_name': 'NOT_CI_ONLY',
+        'filter': "(cohort_week < '2022-06-01' OR meltano_version IS NOT NULL)"
+    },
     "NOT_OPT_OUT": {
+        'parent_name': 'NOT_NULL_VERSION',
         'filter': "has_opted_out = FALSE"
 	},
-    "ADD_OR_INSTALL": {
+    "MINS_5_OR_LONGER": {
         'parent_name': 'NOT_OPT_OUT',
+        'filter': "project_lifespan_mins > 5"
+	},
+    "ADD_OR_INSTALL_ATTEMPT": {
+        'parent_name': 'MINS_5_OR_LONGER',
         'filter': "(ARRAY_CONTAINS( 'add'::VARIANT, cli_command_array ) OR ARRAY_CONTAINS( 'install'::VARIANT, cli_command_array ))"
 	},
-    "EXEC_EVENT": {
-        'parent_name': 'ADD_OR_INSTALL',
+    "ADD_OR_INSTALL_SUCCESS": {
+        'parent_name': 'ADD_OR_INSTALL_ATTEMPT',
+        'filter': "ARRAY_CONTAINS( 'SUCCESS'::VARIANT, add_or_install_completion_status )"
+	},
+    "EXEC_EVENT_ATTEMPT": {
+        'parent_name': 'ADD_OR_INSTALL_SUCCESS',
         'filter': "is_exec_event = TRUE"
 	},
+    "EXEC_EVENT_SUCCESS": {
+        'parent_name': 'EXEC_EVENT_ATTEMPT',
+        'filter': "ARRAY_CONTAINS( 'SUCCESS'::VARIANT, exec_event_completion_status )"
+	},
     "PIPELINE_ATTEMPT": {
-        'parent_name': 'EXEC_EVENT',
+        'parent_name': 'EXEC_EVENT_SUCCESS',
         'filter': "ARRAY_SIZE( pipeline_array ) > 0"
 	},
     "PIPELINE_SUCCESS": {
@@ -20,14 +44,18 @@
 	},
     "GREATER_1_DAY": {
         'parent_name': 'PIPELINE_SUCCESS',
-        'filter': "project_lifespan_days >= 1"
+        'filter': "project_lifespan_hours >= 24"
 	},
     "GREATER_7_DAY": {
         'parent_name': 'GREATER_1_DAY',
-        'filter': "project_lifespan_days >= 7"
+        'filter': "project_lifespan_hours >= (7*24)"
+	},
+    "ACTIVE_EXECUTION": {
+        'parent_name': 'GREATER_7_DAY',
+        'filter': "is_active_cli_execution = TRUE"
 	},
     "STILL_ACTIVE": {
-        'parent_name': 'GREATER_7_DAY',
+        'parent_name': 'ACTIVE_EXECUTION',
         'filter': "is_currently_active = TRUE"
 	}
 	}
@@ -38,21 +66,29 @@ WITH base AS (
     SELECT
         fact_cli_executions.*,
         fact_plugin_usage.completion_status,
-        COALESCE(opt_outs.project_id IS NOT NULL, FALSE) AS has_opted_out
+        COALESCE(opt_outs.project_id IS NOT NULL, FALSE) AS has_opted_out,
+        project_dim.project_lifespan_hours,
+        DATEDIFF(
+            'minute',
+            fact_cli_executions.project_first_event_at,
+            fact_cli_executions.project_last_event_at
+        ) AS project_lifespan_mins
     FROM {{ ref('fact_cli_executions') }}
     LEFT JOIN {{ ref('fact_plugin_usage') }}
         ON fact_cli_executions.execution_id = fact_plugin_usage.execution_id
     LEFT JOIN prep.workspace.opt_outs
         ON fact_cli_executions.project_id = opt_outs.project_id
+    LEFT JOIN {{ ref('project_dim') }}
+        ON fact_cli_executions.project_id = project_dim.project_id
 ),
-single_event AS (
+ci_only AS (
     SELECT
-        project_id,
-        SUM(event_count) AS total_events,
-        MAX(cli_command) AS command
+        base.project_id,
+        MAX(is_ci_environment) AS is_ci_environment,
+        COUNT(DISTINCT COALESCE(is_ci_environment, FALSE)) AS is_ci_environment_count
     FROM base
     GROUP BY 1
-    HAVING total_events = 1
+    HAVING is_ci_environment_count = 1
 ),
 cohort_execs AS (
     SELECT
@@ -64,30 +100,39 @@ cohort_execs AS (
             END
         ) OVER (PARTITION BY base.project_id) AS pipe_completion_statuses,
         ARRAY_AGG(
+            DISTINCT CASE
+                WHEN cli_command IN ('add', 'install') THEN base.completion_status
+            END
+        ) OVER (PARTITION BY base.project_id) AS add_or_install_completion_status,
+        ARRAY_AGG(
+            DISTINCT CASE
+                WHEN is_exec_event THEN base.completion_status
+            END
+        ) OVER (PARTITION BY base.project_id) AS exec_event_completion_status,
+        ARRAY_AGG(
             DISTINCT base.pipeline_fk
         ) OVER (PARTITION BY base.project_id) AS pipeline_array,
         ARRAY_AGG(
             DISTINCT base.cli_command
         ) OVER (PARTITION BY base.project_id) AS cli_command_array,
-        COALESCE(single_event.project_id IS NOT NULL AND command IN ('discover', 'init'), FALSE) AS is_single_event_project
+        COALESCE(ci_only.project_id IS NOT NULL AND ci_only.is_ci_environment = TRUE, FALSE) AS is_ci_only_project
     FROM base
-    LEFT JOIN single_event
-        ON base.project_id = single_event.project_id
+    LEFT JOIN ci_only
+        ON base.project_id = ci_only.project_id
 ),
 
 agg_base AS (
     SELECT
         cohort_week,
         COUNT(
-            DISTINCT CASE WHEN project_id_source != 'random' AND is_single_event_project = FALSE AND cli_command_array != array_construct('discover')
-                THEN project_id END
+            DISTINCT project_id
         ) AS base_all,
         {% for filter_name, attribs in mapping.items() %}
         {{ compounding_funnel_filters(
 			loop.index,
 			filter_name,
 			mapping,
-			"COUNT(DISTINCT CASE WHEN project_id_source != 'random' AND is_single_event_project = FALSE AND cli_command_array != array_construct('discover')",
+			"COUNT(DISTINCT CASE WHEN TRUE",
 			"THEN project_id END)"
 		) }} AS {{ filter_name }}
 			{%- if not loop.last %},{% endif -%}


### PR DESCRIPTION
- Added all filters even things like random, so we can fine tune our filtering logic and know where the drop offs are. This was requested during data office hours.
- Add a new filter at the top of the funnel for `NOT_CI_ONLY` where we only ever saw that project in a CI context
- `NOT_NULL_VERSION` filters for null meltano version after '2022-06-01' because new projects would presumably use the newest meltano package version
- Add a separate "attempt" level before add/install and exec so we can tell if theyre successful or not
- `ACTIVE_EXECUTION` added before the final `STILL_ACTIVE` to differentiate projects that are >7 days old but never executed a plugin after their 7 days. This could be simply stopping right at 7 days or if they run non-exec only after their 7 day window so they never get flipped to "active".

Right now I added a `MINS_5_OR_LONGER` because I was still seeing projects make it through the base filters but a bunch of valid projects were < 60 mins long, you can get a solid amount of exploration done in 60 mins. It did the job but I'm going to attempt to add a filter for this logic `No ‘init’, no ‘add’, no ‘ui’, no ‘config’, lifetime <60 minutes`  in its place, that should cover them as well. That needs more testing first though because my first attempt allowed too many through so I need to see what those projects are doing and how I can tweak it to cover those.

cc @DouweM @tayloramurphy I'm going to merge it in so we see it refreshed in the morning but we can do a few more iterations in the morning, including exchanging the >5 min filter for something smarter (described above).