### PR TITLE
More precise about first meltano version for funnel filters

### DIFF
--- a/data/extract/extractors.meltano.yml
+++ b/data/extract/extractors.meltano.yml
@@ -40,7 +40,7 @@ plugins:
           start_date: "2020-01-01T00:00:00Z"
           key_properties: [id]
           name: azure_ips
-          pattern: "ServiceTags_Public_20220919.json"
+          pattern: "ServiceTags_Public_20221003.json"
           json_path: "values"
   - name: tap-slack
     variant: meltanolabs

--- a/data/transform/models/marts/telemetry/base/hash_lookup.sql
+++ b/data/transform/models/marts/telemetry/base/hash_lookup.sql
@@ -30,6 +30,7 @@ WITH base AS (
         SHA2_HEX(pip_url) AS hash_value,
         'plugin_pip_url' AS category
     FROM {{ ref('snapshot_meltanohub_plugins') }}
+    WHERE pip_url IS NOT NULL
 
     UNION ALL
 

--- a/data/transform/models/marts/telemetry/project_funnel_cohort.sql
+++ b/data/transform/models/marts/telemetry/project_funnel_cohort.sql
@@ -8,7 +8,7 @@
     },
     "NOT_NULL_VERSION": {
         'parent_name': 'NOT_CI_ONLY',
-        'filter': "(cohort_week < '2022-06-01' OR meltano_version IS NOT NULL)"
+        'filter': "(cohort_week < '2022-06-01' OR first_meltano_version IS NOT NULL)"
     },
     "NOT_OPT_OUT": {
         'parent_name': 'NOT_NULL_VERSION',
@@ -127,7 +127,10 @@ cohort_execs AS (
         COALESCE(
             ci_only.project_id IS NOT NULL AND ci_only.is_ci_environment = TRUE,
             FALSE
-        ) AS is_ci_only_project
+        ) AS is_ci_only_project,
+        FIRST_VALUE(
+            base.meltano_version
+        ) OVER (PARTITION BY base.project_id ORDER BY COALESCE(started_ts, date_day) ASC) AS first_meltano_version
     FROM base
     LEFT JOIN ci_only
         ON base.project_id = ci_only.project_id

--- a/data/transform/models/marts/telemetry/project_funnel_cohort.sql
+++ b/data/transform/models/marts/telemetry/project_funnel_cohort.sql
@@ -130,7 +130,11 @@ cohort_execs AS (
         ) AS is_ci_only_project,
         FIRST_VALUE(
             base.meltano_version
-        ) OVER (PARTITION BY base.project_id ORDER BY COALESCE(started_ts, date_day) ASC) AS first_meltano_version
+        ) OVER (
+            PARTITION BY
+                base.project_id
+            ORDER BY COALESCE(base.started_ts, base.date_day) ASC
+        ) AS first_meltano_version
     FROM base
     LEFT JOIN ci_only
         ON base.project_id = ci_only.project_id


### PR DESCRIPTION
I found a few projects that were using multiple meltano versions and if they traversed <2.0 and >2.0 this filter could get confused since it wasnt ordered so I make sure its the version attached to the first event we get from them.