### PR TITLE
feat: parameterize 'prod' environment, create a copy as 'staging'

### DIFF
--- a/data/environments/staging.meltano.yml
+++ b/data/environments/staging.meltano.yml
@@ -1,5 +1,6 @@
+# Originally created from a copy of `prod` environment (`prod.meltano.yml`)
 environments:
-- name: prod
+- name: staging
   config:
     plugins:
       extractors:
@@ -69,9 +70,9 @@ environments:
           role: TRANSFORMER
           warehouse: TRANSFORMER
   env:
-    SF_RAW_DB: RAW
-    SF_PROD_DB: PROD
-    HUB_METRICS_S3_PATH: s3://prod-meltano-bucket-01/hub_metrics/
+    SF_RAW_DB: STAGING_RAW
+    SF_PROD_DB: STAGING_PROD
+    HUB_METRICS_S3_PATH: s3://staging-meltano-bucket-01/hub_metrics/
     PERMISSION_BOT_USER: permission_bot
     PERMISSION_BOT_WAREHOUSE: ADMIN
     PERMISSION_BOT_DATABASE: SNOWFLAKE_SAMPLE_DATA


### PR DESCRIPTION
This will be the execution environment for Managed.

@pnadolny13 - Can you help us get this tested and merged before leaving this week?

Proposed rollout plan (some of these can be performed out of order):

1. [ ] Create new staging DBs in Snowflake so that environments are properly isolated.
2. [ ] Test this new environment and merge to `main` when ready.
3. [ ] Merge the mirror PR here: https://github.com/meltano/dragon-infra/pull/50
4. [ ] Let the new 'staging' environment be executed by Managed. (Environment isolation should prevent side effects.)
5. [ ] Once 'staging' schedule is stable, disable legacy scheduling and enable 'prod' environment schedules in Managed.

