### PR TITLE
singer contrib cleanup

### DIFF
--- a/data/transform/models/marts/community/singer_contributions.sql
+++ b/data/transform/models/marts/community/singer_contributions.sql
@@ -16,8 +16,8 @@ SELECT
     stg_github_search__issues.title,
     stg_github_search__issues.state,
     stg_github_search__repositories.is_fork,
-    stg_meltanohub__plugins.is_default AS is_hub_default,
-    NULL AS is_draft_pr,
+    COALESCE(stg_meltanohub__plugins.is_default, FALSE) AS is_hub_default,
+    FALSE AS is_draft_pr,
     stg_github_search__issues.author_username,
     stg_github_search__issues.assignee_username,
     stg_github_search__issues.comment_count,
@@ -25,28 +25,29 @@ SELECT
     stg_github_search__repositories.num_open_issues,
     stg_github_search__repositories.visibility,
     stg_github_search__repositories.is_archived,
+    stg_github_search__repositories.connector_type,
     stg_github_search__repositories.created_at_ts AS repo_created_at_ts,
     stg_github_search__repositories.last_updated_ts AS repo_updated_at_ts,
-    stg_github_search__repositories.last_push_ts AS repo_last_push_ts
+    stg_github_search__repositories.last_push_ts AS repo_last_push_ts,
+    COALESCE(stg_meltanohub__plugins.repo IS NOT NULL, FALSE) AS is_hub_listed
 FROM {{ ref('stg_github_search__issues') }}
 LEFT JOIN {{ ref('stg_github_search__repositories') }}
     ON
-        lower(
+        LOWER(
             stg_github_search__issues.organization_name
-        ) = lower(
+        ) = LOWER(
             stg_github_search__repositories.repo_namespace
-        ) AND lower(
+        ) AND LOWER(
             stg_github_search__issues.repo_name
-        ) = lower(stg_github_search__repositories.repo_name)
+        ) = LOWER(stg_github_search__repositories.repo_name)
 LEFT JOIN {{ ref('stg_meltanohub__plugins') }}
     ON
-        lower(
+        LOWER(
             stg_meltanohub__plugins.repo
-        ) = lower(stg_github_search__repositories.repo_url)
+        ) = LOWER(stg_github_search__repositories.repo_url)
 LEFT JOIN
     {{ ref('team_github_ids') }} ON
         stg_github_search__issues.author_id = team_github_ids.user_id
-WHERE stg_meltanohub__plugins.repo IS NOT NULL
 
 UNION ALL
 
@@ -68,8 +69,8 @@ SELECT
     stg_github_search__pull_requests.title,
     stg_github_search__pull_requests.state,
     stg_github_search__repositories.is_fork,
-    stg_meltanohub__plugins.is_default AS is_hub_default,
-    stg_github_search__pull_requests.is_draft AS is_draft_pr,
+    COALESCE(stg_meltanohub__plugins.is_default, FALSE) AS is_hub_default,
+    COALESCE(stg_github_search__pull_requests.is_draft, FALSE) AS is_draft_pr,
     stg_github_search__pull_requests.author_username,
     stg_github_search__pull_requests.assignee_username,
     stg_github_search__pull_requests.comment_count,
@@ -77,25 +78,26 @@ SELECT
     stg_github_search__repositories.num_open_issues,
     stg_github_search__repositories.visibility,
     stg_github_search__repositories.is_archived,
+    stg_github_search__repositories.connector_type,
     stg_github_search__repositories.created_at_ts AS repo_created_at_ts,
     stg_github_search__repositories.last_updated_ts AS repo_updated_at_ts,
-    stg_github_search__repositories.last_push_ts AS repo_last_push_ts
+    stg_github_search__repositories.last_push_ts AS repo_last_push_ts,
+    COALESCE(stg_meltanohub__plugins.repo IS NOT NULL, FALSE) AS is_hub_listed
 FROM {{ ref('stg_github_search__pull_requests') }}
 LEFT JOIN {{ ref('stg_github_search__repositories') }}
     ON
-        lower(
+        LOWER(
             stg_github_search__pull_requests.organization_name
-        ) = lower(
+        ) = LOWER(
             stg_github_search__repositories.repo_namespace
-        ) AND lower(
+        ) AND LOWER(
             stg_github_search__pull_requests.repo_name
-        ) = lower(stg_github_search__repositories.repo_name)
+        ) = LOWER(stg_github_search__repositories.repo_name)
 LEFT JOIN {{ ref('stg_meltanohub__plugins') }}
     ON
-        lower(
+        LOWER(
             stg_meltanohub__plugins.repo
-        ) = lower(stg_github_search__repositories.repo_url)
+        ) = LOWER(stg_github_search__repositories.repo_url)
 LEFT JOIN
     {{ ref('team_github_ids') }} ON
         stg_github_search__pull_requests.author_id = team_github_ids.user_id
-WHERE stg_meltanohub__plugins.repo IS NOT NULL

--- a/data/transform/models/publish/slack_notifications/slack_alerts.sql
+++ b/data/transform/models/publish/slack_notifications/slack_alerts.sql
@@ -68,6 +68,7 @@ base AS (
     FROM {{ ref('singer_contributions') }}
     CROSS JOIN most_recent_date
     WHERE singer_contributions.is_bot_user = FALSE
+        AND singer_contributions.is_hub_listed = TRUE
 )
 
 SELECT


### PR DESCRIPTION
- add connector type
- allow repos not listed on the hub
- add is_hub_listed flag now that non listed repos are included
- cast boolean nulls to false to be cleaner
- slack alerts still filter for only hub listed activity to avoid noisey non-listed repos