### PR TITLE
add more end of month attributes to daily active projects

### DIFF
--- a/data/transform/models/marts/telemetry/daily_active_projects.sql
+++ b/data/transform/models/marts/telemetry/daily_active_projects.sql
@@ -110,8 +110,11 @@ SELECT
         FALSE
     ) AS is_active_month_end,
     COALESCE(
-        is_active_month_start = is_active_month_end, FALSE
-    ) AS eom_unchanged,
+        is_active_month_start = TRUE AND is_active_month_end = TRUE, FALSE
+    ) AS eom_active_unchanged,
+    COALESCE(
+        is_active_month_start = FALSE AND is_active_month_end = FALSE, FALSE
+    ) AS eom_inactive_unchanged,
     COALESCE(
         is_active_month_start = TRUE AND is_active_month_end = FALSE, FALSE
     ) AS eom_churned,

--- a/data/transform/models/marts/telemetry/daily_active_projects.sql
+++ b/data/transform/models/marts/telemetry/daily_active_projects.sql
@@ -57,8 +57,77 @@ project_activity_status AS (
             ELSE FALSE
         END AS is_last_active_date
     FROM daily_project_active
+),
+
+base_daily AS (
+
+    SELECT *
+    FROM project_activity_status
+    WHERE date_day <= CURRENT_TIMESTAMP()
+
+),
+
+base_monthly AS (
+    SELECT
+        project_id,
+        last_day_of_month,
+        DATE_TRUNC(MONTH, last_day_of_month) AS first_day_of_month,
+        MIN(date_day) AS min_month_active_dt,
+        MAX(date_day) AS max_month_active_dt,
+        MAX(CASE WHEN is_added_date THEN date_day END) AS max_added_dt,
+        MAX(CASE WHEN is_last_active_date THEN date_day END) AS max_last_day_dt
+    FROM base_daily
+    GROUP BY 1, 2
 )
 
-SELECT *
-FROM project_activity_status
-WHERE date_day <= CURRENT_TIMESTAMP()
+SELECT
+    base_daily.date_day,
+    base_daily.last_day_of_month,
+    base_daily.project_id,
+    base_daily.is_added_date,
+    base_daily.is_reactivated_date,
+    base_daily.is_last_active_date,
+    base_monthly.min_month_active_dt,
+    base_monthly.max_month_active_dt,
+    COALESCE(
+        base_monthly.min_month_active_dt
+        = base_monthly.first_day_of_month
+        AND COALESCE(
+            base_monthly.max_added_dt
+            != base_monthly.first_day_of_month,
+            TRUE
+        ),
+        FALSE
+    ) AS is_active_month_start,
+    COALESCE(
+        base_monthly.max_month_active_dt
+        = base_monthly.last_day_of_month
+        AND COALESCE(
+            base_monthly.max_last_day_dt
+            != base_monthly.last_day_of_month,
+            TRUE
+        ),
+        FALSE
+    ) AS is_active_month_end,
+    COALESCE(
+        is_active_month_start = is_active_month_end, FALSE
+    ) AS eom_unchanged,
+    COALESCE(
+        is_active_month_start = TRUE AND is_active_month_end = FALSE, FALSE
+    ) AS eom_churned,
+    COALESCE(
+        is_active_month_start = FALSE
+        AND is_active_month_end = TRUE
+        AND base_monthly.max_added_dt IS NOT NULL,
+        FALSE
+    ) AS eom_added,
+    COALESCE(
+        is_active_month_start = FALSE
+        AND is_active_month_end = TRUE
+        AND base_monthly.max_added_dt IS NULL,
+        FALSE
+    ) AS eom_reactivated
+FROM base_daily
+LEFT JOIN base_monthly
+    ON base_daily.project_id = base_monthly.project_id
+        AND base_daily.last_day_of_month = base_monthly.last_day_of_month


### PR DESCRIPTION
Related to https://github.com/meltano/internal-data/issues/36

This adds attributes for end of month. The comparison is now based on the start and end status. If you came in as active and left active, youre unchanged we dont care if you churned then reactivated in the same month if you didnt change status MoM. Additionally if you were added then churned before the end of the month youre unchanged because you change inactive and left inactive.