### PR TITLE
use target-apprise fork

### DIFF
--- a/data/load/loaders.meltano.yml
+++ b/data/load/loaders.meltano.yml
@@ -48,4 +48,4 @@ plugins:
       password: ${SNOWFLAKE_PASSWORD}
   - name: target-apprise
     variant: AutoIDM
-    pip_url: target-apprise
+    pip_url: git+https://github.com/pnadolny13/target-apprise.git@apprise_bugfix_commit_pinned


### PR DESCRIPTION
- This issue was fixed https://github.com/caronc/apprise/issues/721 that was the cause of the slack markdown not rendering
- Use a personal fork of target-apprise that pins the apprise commit hash of the fix until the next release
- After the release I'll get it bumped properly in target-apprise (autoidm)