### PR TITLE
run dbt deps for cloud deployment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,7 +104,7 @@ jobs:
     # Install Plugins
     - run: eval $(meltano job list --format=json | python ci_get_install_script.py ${{ matrix.extract-source }})
     # Run Test
-    - run: meltano run dbt-snowflake:deps ${{ matrix.extract-source }}
+    - run: meltano run ${{ matrix.extract-source }}
 
   transform_tests:
     runs-on: ubuntu-latest
@@ -153,4 +153,4 @@ jobs:
     # Install Plugins
     - run: eval $(meltano job list --format=json | python ci_get_install_script.py hub_metrics_publish)
     # Run Test
-    - run: meltano run dbt-snowflake:deps hub_metrics_publish
+    - run: meltano run hub_metrics_publish

--- a/data/orchestrate/orchestrators.meltano.yml
+++ b/data/orchestrate/orchestrators.meltano.yml
@@ -59,69 +59,69 @@ jobs:
 
 - name: slack_notifications
   tasks:
-  - dbt-snowflake:run_slack_notifications
+  - dbt-snowflake:deps dbt-snowflake:run_slack_notifications
   - tap-snowflake-singer-activity target-apprise
 
 - name: dbt_docs
   tasks:
-  - dbt-snowflake:docs-generate
-  - dbt-snowflake:docs-serve
+  - dbt-snowflake:deps dbt-snowflake:docs-generate
+  - dbt-snowflake:deps dbt-snowflake:docs-serve
 
 - name: meltanohub_el
   tasks:
   - tap-meltanohub target-snowflake
-  - dbt-snowflake:test_source_meltanohub
-  - dbt-snowflake:run_snapshot_meltanohub
-  - dbt-snowflake:run_staging_meltanohub
-  - dbt-snowflake:test_staging_meltanohub
+  - dbt-snowflake:deps dbt-snowflake:test_source_meltanohub
+  - dbt-snowflake:deps dbt-snowflake:run_snapshot_meltanohub
+  - dbt-snowflake:deps dbt-snowflake:run_staging_meltanohub
+  - dbt-snowflake:deps dbt-snowflake:test_staging_meltanohub
 
 - name: spreadsheets_anywhere_el
   tasks:
   - tap-spreadsheets-anywhere coalesce-gcp-ips target-snowflake
-  - dbt-snowflake:test_source_spreadsheets_anywhere
-  - dbt-snowflake:run_snapshot_spreadsheets_anywhere
+  - dbt-snowflake:deps dbt-snowflake:test_source_spreadsheets_anywhere
+  - dbt-snowflake:deps dbt-snowflake:run_snapshot_spreadsheets_anywhere
 
 - name: snowplow_el
   tasks:
-  - dbt-snowflake:run_staging_snowplow
-  - dbt-snowflake:test_staging_snowplow
+  - dbt-snowflake:deps dbt-snowflake:run_staging_snowplow
+  - dbt-snowflake:deps dbt-snowflake:test_staging_snowplow
 
 - name: github_search_el
   tasks:
   - tap-github-search target-snowflake
-  - dbt-snowflake:run_staging_github_search
-  - dbt-snowflake:test_staging_github_search
+  - dbt-snowflake:deps dbt-snowflake:run_staging_github_search
+  - dbt-snowflake:deps dbt-snowflake:test_staging_github_search
 
 - name: github_meltano_el
   tasks:
   - tap-github-meltano target-snowflake
-  - dbt-snowflake:run_staging_github_meltano
-  - dbt-snowflake:test_staging_github_meltano
+  - dbt-snowflake:deps dbt-snowflake:run_staging_github_meltano
+  - dbt-snowflake:deps dbt-snowflake:test_staging_github_meltano
 
 - name: gitlab_el
   tasks:
   - tap-gitlab target-snowflake
-  - dbt-snowflake:run_staging_gitlab
-  - dbt-snowflake:test_staging_gitlab
+  - dbt-snowflake:deps dbt-snowflake:run_staging_gitlab
+  - dbt-snowflake:deps dbt-snowflake:test_staging_gitlab
 
 - name: slack_el
   tasks:
   - tap-slack target-snowflake 
   - tap-slack-public target-snowflake
-  - dbt-snowflake:run_staging_slack
-  - dbt-snowflake:test_staging_slack
+  - dbt-snowflake:deps dbt-snowflake:run_staging_slack
+  - dbt-snowflake:deps dbt-snowflake:test_staging_slack
 
 - name: google_analytics_el
   tasks:
   - tap-google-analytics target-snowflake
   # - great_expectations:test_ga_raw
-  - dbt-snowflake:run_staging_google_analytics
-  - dbt-snowflake:test_staging_google_analytics
+  - dbt-snowflake:deps dbt-snowflake:run_staging_google_analytics
+  - dbt-snowflake:deps dbt-snowflake:test_staging_google_analytics
 
 - name: hub_metrics_publish
   tasks:
-  - dbt-snowflake:run_hub_metrics
-  - dbt-snowflake:test_hub_metrics
+  - dbt-snowflake:deps dbt-snowflake:run_hub_metrics
+  - dbt-snowflake:deps dbt-snowflake:test_hub_metrics
   # - great_expectations:test_dbt_hub_metrics
   - tap-snowflake-metrics target-yaml-metrics awscli:s3_copy_metrics
   - tap-snowflake-metrics-legacy target-yaml-metrics-legacy awscli:s3_copy_metrics_legacy
@@ -129,5 +129,5 @@ jobs:
 
 - name: marts_refresh
   tasks:
-  - dbt-snowflake:run_marts
-  - dbt-snowflake:test_marts
+  - dbt-snowflake:deps dbt-snowflake:run_marts
+  - dbt-snowflake:deps dbt-snowflake:test_marts

--- a/deploy/meltano/Dockerfile.meltano
+++ b/deploy/meltano/Dockerfile.meltano
@@ -19,7 +19,5 @@ RUN meltano install utilities great_expectations awscli
 ENV MELTANO_PROJECT_ROOT /project
 ENV MELTANO_PROJECT_READONLY 1
 
-RUN meltano invoke dbt-snowflake:deps
-
 ENTRYPOINT [ "/bin/sh", "-c" ]
 CMD ["meltano"]


### PR DESCRIPTION
 Related to https://meltano.slack.com/archives/C043KMHQ8NN/p1668707781811419?thread_ts=1668703942.507089&cid=C043KMHQ8NN

For deploying to cloud we no longer have the ability to run deps once in the image build process since cloud installs the project into a shell meltano container. In every task we now run deps before any dbt runs. Done at the task level in case cloud ends up parallelizing tasks within a job.

Also noting that the EDK based dbt plugin version would automatically do this for us https://github.com/meltano/squared/pull/411. But for stability sake I preferred to do it this way for now vs replacing the plugin.