### PR TITLE
refactor funnel model to use new project_dim attributes

### DIFF
--- a/data/transform/models/marts/telemetry/project_funnel_cohort.sql
+++ b/data/transform/models/marts/telemetry/project_funnel_cohort.sql
@@ -4,11 +4,11 @@
     },
     "NOT_CI_ONLY": {
         'parent_name': 'NOT_RANDOM',
-        'filter': "is_ci_only_project = FALSE"
+        'filter': "is_ci_only = FALSE"
     },
     "NOT_NULL_VERSION": {
         'parent_name': 'NOT_CI_ONLY',
-        'filter': "(cohort_week < '2022-06-01' OR first_meltano_version IS NOT NULL)"
+        'filter': "(cohort_week < '2022-06-01' OR first_meltano_version != 'UNKNOWN')"
     },
     "NOT_OPT_OUT": {
         'parent_name': 'NOT_NULL_VERSION',
@@ -20,27 +20,27 @@
 	},
     "ADD_OR_INSTALL_ATTEMPT": {
         'parent_name': 'MINS_5_OR_LONGER',
-        'filter': "(ARRAY_CONTAINS( 'add'::VARIANT, cli_command_array ) OR ARRAY_CONTAINS( 'install'::VARIANT, cli_command_array ))"
+        'filter': "(add_count_all > 0 OR install_count_all > 0)"
 	},
     "ADD_OR_INSTALL_SUCCESS": {
         'parent_name': 'ADD_OR_INSTALL_ATTEMPT',
-        'filter': "ARRAY_CONTAINS( 'SUCCESS'::VARIANT, add_or_install_completion_status )"
+        'filter': "(add_count_success > 0 OR install_count_success > 0)"
 	},
     "EXEC_EVENT_ATTEMPT": {
         'parent_name': 'ADD_OR_INSTALL_SUCCESS',
-        'filter': "is_exec_event_lifetime = TRUE"
+        'filter': "exec_event_total > 0"
 	},
     "EXEC_EVENT_SUCCESS": {
         'parent_name': 'EXEC_EVENT_ATTEMPT',
-        'filter': "ARRAY_CONTAINS( 'SUCCESS'::VARIANT, exec_event_completion_status )"
+        'filter': "exec_event_success_total > 0"
 	},
     "PIPELINE_ATTEMPT": {
         'parent_name': 'EXEC_EVENT_SUCCESS',
-        'filter': "ARRAY_SIZE( pipeline_array ) > 0"
+        'filter': "pipeline_runs_count_all > 0"
 	},
     "PIPELINE_SUCCESS": {
         'parent_name': 'PIPELINE_ATTEMPT',
-        'filter': "ARRAY_CONTAINS( 'SUCCESS'::VARIANT, pipe_completion_statuses )"
+        'filter': "pipeline_runs_count_success > 0"
 	},
     "ADD_OR_INSTALL_NON_GSG": {
         'parent_name': 'PIPELINE_SUCCESS',
@@ -76,196 +76,33 @@
 	},
     "ACTIVE_EXECUTION": {
         'parent_name': 'GREATER_7_DAY',
-        'filter': "is_active_cli_execution_lifetime = TRUE"
+        'filter': "active_executions_count > 0"
 	},
     "STILL_ACTIVE": {
         'parent_name': 'ACTIVE_EXECUTION',
-        'filter': "is_currently_active_lifetime = TRUE"
+        'filter': "is_currently_active = TRUE"
 	}
 	}
 %}
 
+WITH active_executions AS (
 
-WITH base AS (
-    SELECT
-        fact_cli_executions.*,
-        fact_plugin_usage.completion_status,
-        fact_plugin_usage.plugin_name,
-        fact_plugin_usage.plugin_type,
-        project_dim.project_lifespan_hours,
-        COALESCE(opt_outs.project_id IS NOT NULL, FALSE) AS has_opted_out,
-        DATEDIFF(
-            'minute',
-            fact_cli_executions.project_first_event_at,
-            fact_cli_executions.project_last_event_at
-        ) AS project_lifespan_mins
-    FROM {{ ref('fact_cli_executions') }}
-    LEFT JOIN {{ ref('fact_plugin_usage') }}
-        ON fact_cli_executions.execution_id = fact_plugin_usage.execution_id
-    LEFT JOIN {{ ref('opt_outs') }}
-        ON fact_cli_executions.project_id = opt_outs.project_id
-    LEFT JOIN {{ ref('project_dim') }}
-        ON fact_cli_executions.project_id = project_dim.project_id
-),
-
-ci_only AS (
-    SELECT
-        base.project_id,
-        MAX(is_ci_environment) AS is_ci_environment,
-        COUNT(
-            DISTINCT COALESCE(is_ci_environment, FALSE)
-        ) AS is_ci_environment_count
-    FROM base
-    GROUP BY 1
-    HAVING is_ci_environment_count = 1
-),
-
-project_attribs AS (
     SELECT
         project_id,
-        MAX(is_exec_event) AS is_exec_event_lifetime,
-        MAX(is_active_cli_execution) AS is_active_cli_execution_lifetime,
-        MAX(is_currently_active) AS is_currently_active_lifetime,
-        COUNT(
-            DISTINCT CASE
-                WHEN cli_command IN ('add', 'install')
-                    AND plugin_name NOT IN (
-                        'tap-gitlab',
-                        'tap-github',
-                        'target-jsonl',
-                        'target-postgres'
-                    )
-                    AND plugin_type IN ('extractors', 'loaders')
-                    THEN plugin_name
-            END
-        ) AS non_gsg_add,
-        COUNT(
-            DISTINCT CASE
-                WHEN cli_command IN ('add', 'install')
-                    AND plugin_name NOT IN (
-                        'tap-gitlab',
-                        'tap-github',
-                        'target-jsonl',
-                        'target-postgres'
-                    )
-                    AND plugin_type IN ('extractors', 'loaders')
-                    AND completion_status = 'SUCCESS'
-                    THEN plugin_name
-            END
-        ) AS non_gsg_add_success,
-        COUNT(
-            DISTINCT CASE
-                WHEN is_exec_event
-                    AND plugin_name NOT IN (
-                        'tap-gitlab',
-                        'tap-github',
-                        'target-jsonl',
-                        'target-postgres'
-                    )
-                    AND plugin_type IN ('extractors', 'loaders')
-                    THEN plugin_name
-            END
-        ) AS non_gsg_exec,
-        COUNT(
-            DISTINCT CASE
-                WHEN is_exec_event
-                    AND plugin_name NOT IN (
-                        'tap-gitlab',
-                        'tap-github',
-                        'target-jsonl',
-                        'target-postgres'
-                    )
-                    AND plugin_type IN ('extractors', 'loaders')
-                    AND completion_status = 'SUCCESS'
-                    THEN plugin_name
-            END
-        ) AS non_gsg_exec_success,
-        COUNT(
-            DISTINCT CASE
-                WHEN pipeline_fk IS NOT NULL
-                    AND plugin_name NOT IN (
-                        'tap-gitlab',
-                        'tap-github',
-                        'target-jsonl',
-                        'target-postgres'
-                    )
-                    AND plugin_type IN ('extractors', 'loaders')
-                    THEN plugin_name
-            END
-        ) AS non_gsg_pipeline,
-        COUNT(
-            DISTINCT CASE
-                WHEN pipeline_fk IS NOT NULL
-                    AND plugin_name NOT IN (
-                        'tap-gitlab',
-                        'tap-github',
-                        'target-jsonl',
-                        'target-postgres'
-                    )
-                    AND plugin_type IN ('extractors', 'loaders')
-                    AND completion_status = 'SUCCESS'
-                    THEN plugin_name
-            END
-        ) AS non_gsg_pipeline_success
-    FROM base
+        SUM(CASE WHEN is_active_cli_execution THEN 1 END) AS active_executions_count
+    FROM {{ ref('fact_cli_executions') }}
     GROUP BY 1
 ),
 
-cohort_execs AS (
+project_base AS (
+
     SELECT
-        base.*,
-        project_attribs.is_exec_event_lifetime,
-        project_attribs.is_active_cli_execution_lifetime,
-        project_attribs.is_currently_active_lifetime,
-        project_attribs.non_gsg_add,
-        project_attribs.non_gsg_add_success,
-        project_attribs.non_gsg_exec,
-        project_attribs.non_gsg_exec_success,
-        project_attribs.non_gsg_pipeline,
-        project_attribs.non_gsg_pipeline_success,
-        DATE_TRUNC(WEEK, base.project_first_event_at) AS cohort_week,
-        ARRAY_AGG(
-            DISTINCT CASE
-                WHEN base.pipeline_fk IS NOT NULL THEN base.completion_status
-            END
-        ) OVER (PARTITION BY base.project_id) AS pipe_completion_statuses,
-        ARRAY_AGG(
-            DISTINCT CASE
-                WHEN
-                    base.cli_command IN (
-                        'add', 'install'
-                    ) THEN base.completion_status
-            END
-        ) OVER (
-            PARTITION BY base.project_id
-        ) AS add_or_install_completion_status,
-        ARRAY_AGG(
-            DISTINCT CASE
-                WHEN base.is_exec_event THEN base.completion_status
-            END
-        ) OVER (PARTITION BY base.project_id) AS exec_event_completion_status,
-        ARRAY_AGG(
-            DISTINCT base.pipeline_fk
-        ) OVER (PARTITION BY base.project_id) AS pipeline_array,
-        ARRAY_AGG(
-            DISTINCT base.cli_command
-        ) OVER (PARTITION BY base.project_id) AS cli_command_array,
-        COALESCE(
-            ci_only.project_id IS NOT NULL AND ci_only.is_ci_environment = TRUE,
-            FALSE
-        ) AS is_ci_only_project,
-        FIRST_VALUE(
-            base.meltano_version
-        ) OVER (
-            PARTITION BY
-                base.project_id
-            ORDER BY COALESCE(base.started_ts, base.date_day) ASC
-        ) AS first_meltano_version
-    FROM base
-    LEFT JOIN ci_only
-        ON base.project_id = ci_only.project_id
-    LEFT JOIN project_attribs
-        ON base.project_id = project_attribs.project_id
+        DATE_TRUNC(WEEK, project_first_event_at) AS cohort_week,
+        active_executions.active_executions_count,
+        project_dim.*
+    FROM {{ ref('project_dim') }}
+    LEFT JOIN active_executions
+        ON project_dim.project_id = active_executions.project_id
 
 ),
 
@@ -285,7 +122,7 @@ agg_base AS (
 		) }} AS {{ filter_name }}
 			{%- if not loop.last %},{% endif -%}
 		{% endfor %}
-    FROM cohort_execs
+    FROM project_base
     GROUP BY 1
 )
 

--- a/data/transform/models/marts/telemetry/project_funnel_cohort.sql
+++ b/data/transform/models/marts/telemetry/project_funnel_cohort.sql
@@ -89,7 +89,9 @@ WITH active_executions AS (
 
     SELECT
         project_id,
-        SUM(CASE WHEN is_active_cli_execution THEN 1 END) AS active_executions_count
+        SUM(
+            CASE WHEN is_active_cli_execution THEN 1 END
+        ) AS active_executions_count
     FROM {{ ref('fact_cli_executions') }}
     GROUP BY 1
 ),
@@ -97,9 +99,9 @@ WITH active_executions AS (
 project_base AS (
 
     SELECT
-        DATE_TRUNC(WEEK, project_first_event_at) AS cohort_week,
+        project_dim.*,
         active_executions.active_executions_count,
-        project_dim.*
+        DATE_TRUNC(WEEK, project_dim.project_first_event_at) AS cohort_week
     FROM {{ ref('project_dim') }}
     LEFT JOIN active_executions
         ON project_dim.project_id = active_executions.project_id


### PR DESCRIPTION
Closes https://github.com/meltano/squared/issues/477

A few things to note:
- The logic for determining a project's first meltano version slightly changed as part of the move from the funnel model to the more robust implementation in project_dim. It ended up have a very time positive affect (like <5 projects max, mostly no difference or 1 project) where some projects were looking like they had a null meltano version but it wasnt there actual first event. This happens because some projects were also sending legacy structured events around the transistion time near the 2.0 launch so they have null versions and since the structured event timestamps arent as precise so the old logic was treating them as first events when sometimes they werent.
- The meltano version logic change had a positive bump at the top of the funnel so some of the later funnel levels also got the same or similar bump.
- After spending more dedicated time (I was spot checking individual project activity to verify) on this I'm more confident in these numbers and know that its more accurate than before.

cc @tayloramurphy 