### PR TITLE
target-apprise back to AutoIDM after version bump

### DIFF
--- a/data/load/loaders.meltano.yml
+++ b/data/load/loaders.meltano.yml
@@ -48,4 +48,4 @@ plugins:
       password: ${SNOWFLAKE_PASSWORD}
   - name: target-apprise
     variant: AutoIDM
-    pip_url: git+https://github.com/pnadolny13/target-apprise.git@apprise_bugfix_commit_pinned
+    pip_url: target-apprise==0.0.2


### PR DESCRIPTION
Closes https://github.com/meltano/squared/issues/472

- switch back to AutoIDM repo
- bump version since it now uses the new version of apprise that support slack markdown better