### PR TITLE
slack notifications include singer repos

### DIFF
--- a/data/environments/userdev.meltano.yml
+++ b/data/environments/userdev.meltano.yml
@@ -56,6 +56,7 @@ environments:
           user: ${USER_PREFIX}
           role: ${USER_PREFIX}
           warehouse: CORE
+          skip_pre_invoke: True
           database: USERDEV_PROD
           database_prep: USERDEV_PREP
           database_raw: RAW

--- a/data/transform/macros/slack_message_generator.sql
+++ b/data/transform/macros/slack_message_generator.sql
@@ -1,3 +1,3 @@
 {% macro slack_message_generator() -%}
-'\n     • <' || html_url || ' | ' || organization_name || '/' || repo_name || ' #' || GET(split(html_url, '/'), 6)::STRING || '> (*' || author_username || '*): _' || title || '_\n'
+'\n     • <' || html_url || ' | ' || organization_name || '/' || repo_name || ' #' || GET(split(html_url, '/'), 6)::STRING || '> (*' || author_username || '*) ' || CASE WHEN singer_contributions.is_hub_listed THEN ':melty-flame:' ELSE ':singer-logo:' END || ' : _' || title || '_\n'
 {%- endmacro %}

--- a/data/transform/macros/slack_message_generator.sql
+++ b/data/transform/macros/slack_message_generator.sql
@@ -1,3 +1,3 @@
 {% macro slack_message_generator() -%}
-'\n     • <' || html_url || ' | ' || organization_name || '/' || repo_name || ' #' || GET(split(html_url, '/'), 6)::STRING || '> (*' || author_username || '*) ' || CASE WHEN singer_contributions.is_hub_listed THEN ':melty-flame:' ELSE ':singer-logo:' END || ' : _' || title || '_\n'
+'\n     • <' || html_url || ' | ' || organization_name || '/' || repo_name || ' #' || GET(split(html_url, '/'), 6)::STRING || '> (*' || author_username || '*) ' || CASE WHEN singer_contributions.is_hub_listed THEN ':melty-flame:' END || ' : _' || title || '_\n'
 {%- endmacro %}

--- a/data/transform/models/publish/slack_notifications/slack_alerts.sql
+++ b/data/transform/models/publish/slack_notifications/slack_alerts.sql
@@ -68,7 +68,6 @@ base AS (
     FROM {{ ref('singer_contributions') }}
     CROSS JOIN most_recent_date
     WHERE singer_contributions.is_bot_user = FALSE
-        AND singer_contributions.is_hub_listed = TRUE
 )
 
 SELECT


### PR DESCRIPTION
We were only including hub listed repos in the alerts previously. Now we include all and add a little melty emoji to signify that its hub listed.