### PR TITLE
Project directory attribute - codespace demo funnel

### DIFF
--- a/data/transform/models/marts/telemetry/base/cli_executions_base.sql
+++ b/data/transform/models/marts/telemetry/base/cli_executions_base.sql
@@ -91,6 +91,7 @@ combined AS (
         NULL AS meltano_version,
         NULL AS python_version,
         NULL AS is_ci_environment,
+        NULL AS options_obj,
         event_commands_parsed.is_legacy_event,
         -- Plugins
         event_commands_parsed.is_plugin_dbt,
@@ -170,6 +171,7 @@ combined AS (
         unstructured_executions.meltano_version,
         unstructured_executions.python_version,
         unstructured_executions.is_ci_environment,
+        unstructured_executions.options_obj,
         COALESCE(unstructured_executions.cli_command IN (
                 'meltano transforms',
                 'meltano dashboards',
@@ -245,6 +247,7 @@ SELECT
     combined.exit_code,
     combined.is_tracking_disabled,
     combined.is_ci_environment,
+    combined.options_obj,
     combined.is_legacy_event,
     combined.is_plugin_dbt,
     combined.is_plugin_singer,

--- a/data/transform/models/marts/telemetry/fact_cli_executions.sql
+++ b/data/transform/models/marts/telemetry/fact_cli_executions.sql
@@ -17,6 +17,7 @@ WITH base AS (
         project_dim.is_ephemeral_project_id,
         project_dim.project_id_source,
         project_dim.is_currently_active,
+        project_dim.init_project_directory,
         -- Pipeline Attributes
         pipeline_dim.pipeline_pk AS pipeline_fk,
         pipeline_executions.pipeline_runtime_bin,
@@ -142,6 +143,7 @@ SELECT
     base.is_ephemeral_project_id,
     base.project_id_source,
     base.is_currently_active,
+    base.init_project_directory,
     base.pipeline_fk,
     base.pipeline_runtime_bin,
     base.event_count,

--- a/data/transform/models/marts/telemetry/fact_plugin_usage.sql
+++ b/data/transform/models/marts/telemetry/fact_plugin_usage.sql
@@ -42,6 +42,7 @@ SELECT
     project_dim.is_ephemeral_project_id,
     project_dim.is_currently_active,
     project_dim.project_id_source,
+    project_dim.init_project_directory,
     ip_address_dim.cloud_provider,
     ip_address_dim.execution_location,
     -- Pipeline Attributes

--- a/data/transform/models/marts/telemetry/project_dim.sql
+++ b/data/transform/models/marts/telemetry/project_dim.sql
@@ -23,6 +23,7 @@ SELECT
     project_base.opted_out_at,
     project_base.first_meltano_version,
     project_base.last_meltano_version,
+    project_base.init_project_directory,
     project_base.has_opted_out,
     COALESCE(project_base.event_total, 0) AS event_total,
     COALESCE(project_base.exec_event_total, 0) AS exec_event_total,

--- a/data/transform/models/marts/telemetry/project_dim.sql
+++ b/data/transform/models/marts/telemetry/project_dim.sql
@@ -129,7 +129,19 @@ SELECT
         project_base.lifespan_hours <= 24
         AND project_base.first_event_at::DATE != CURRENT_DATE,
         FALSE
-    ) AS is_ephemeral_project_id
+    ) AS is_ephemeral_project_id,
+    COALESCE(
+        project_base.init_project_directory IN (
+            'e5ca2eeb4da09ea1a66c3d9391b5bf43296e309c619c04914ac5bffbb3e7cf54', -- `new_project` original path
+            '781d839e18d017b347cf90a22e18b407e3cdacb2a9cc907d3693893a790fdc4c'), -- `b54c6cfe2f8f831389a5b9ca409f410c` new UUID path
+        FALSE
+    ) AS is_codespace_demo,
+    COALESCE(
+        project_base.init_project_directory IN (
+            'edd9334eaeaa3b81f964e18c5840955de8791ea220740459f7393deca03085f6', -- `my-meltano-project` full tutorial
+            'ffd7f2044d5bf2efc6bd4353979041951c565125c08186e3160be926a6ee1e75'), -- `my-new-project` new GSG tutuorial
+        FALSE
+    ) AS is_gsg_tutorial
 FROM {{ ref('project_base') }}
 LEFT JOIN
     active_projects ON

--- a/data/transform/models/marts/telemetry/project_dim.sql
+++ b/data/transform/models/marts/telemetry/project_dim.sql
@@ -132,14 +132,18 @@ SELECT
     ) AS is_ephemeral_project_id,
     COALESCE(
         project_base.init_project_directory IN (
-            'e5ca2eeb4da09ea1a66c3d9391b5bf43296e309c619c04914ac5bffbb3e7cf54', -- `new_project` original path
-            '781d839e18d017b347cf90a22e18b407e3cdacb2a9cc907d3693893a790fdc4c'), -- `b54c6cfe2f8f831389a5b9ca409f410c` new UUID path
+            -- codespace original path - 'PosixPath(\'new_project\')'
+            'e5ca2eeb4da09ea1a66c3d9391b5bf43296e309c619c04914ac5bffbb3e7cf54',
+            -- updated uuid - 'PosixPath(\'b54c6cfe2f8f831389a5b9ca409f410c\')'
+            '781d839e18d017b347cf90a22e18b407e3cdacb2a9cc907d3693893a790fdc4c'),
         FALSE
     ) AS is_codespace_demo,
     COALESCE(
         project_base.init_project_directory IN (
-            'edd9334eaeaa3b81f964e18c5840955de8791ea220740459f7393deca03085f6', -- `my-meltano-project` full tutorial
-            'ffd7f2044d5bf2efc6bd4353979041951c565125c08186e3160be926a6ee1e75'), -- `my-new-project` new GSG tutuorial
+            -- full GSG tutorial path - 'PosixPath(\'my-meltano-project\')'
+            'edd9334eaeaa3b81f964e18c5840955de8791ea220740459f7393deca03085f6',
+            -- mulit part GSG tutorial path - 'PosixPath(\'my-new-project\')'
+            'ffd7f2044d5bf2efc6bd4353979041951c565125c08186e3160be926a6ee1e75'),
         FALSE
     ) AS is_gsg_tutorial
 FROM {{ ref('project_base') }}

--- a/data/transform/models/marts/telemetry/project_funnel_cohort_codespaces.sql
+++ b/data/transform/models/marts/telemetry/project_funnel_cohort_codespaces.sql
@@ -1,0 +1,147 @@
+{% set mapping = {
+    "NOT_RANDOM": {
+        'filter': "project_id_source != 'random'"
+    },
+    "NOT_CI_ONLY": {
+        'parent_name': 'NOT_RANDOM',
+        'filter': "is_ci_only = FALSE"
+    },
+    "NOT_NULL_VERSION": {
+        'parent_name': 'NOT_CI_ONLY',
+        'filter': "(cohort_week < '2022-06-01' OR first_meltano_version != 'UNKNOWN')"
+    },
+    "NOT_OPT_OUT": {
+        'parent_name': 'NOT_NULL_VERSION',
+        'filter': "has_opted_out = FALSE"
+	},
+    "MINS_5_OR_LONGER": {
+        'parent_name': 'NOT_OPT_OUT',
+        'filter': "project_lifespan_mins > 5"
+	},
+    "ADD_OR_INSTALL_ATTEMPT": {
+        'parent_name': 'MINS_5_OR_LONGER',
+        'filter': "(add_count_all > 0 OR install_count_all > 0)"
+	},
+    "ADD_OR_INSTALL_SUCCESS": {
+        'parent_name': 'ADD_OR_INSTALL_ATTEMPT',
+        'filter': "(add_count_success > 0 OR install_count_success > 0)"
+	},
+    "EXEC_EVENT_ATTEMPT": {
+        'parent_name': 'ADD_OR_INSTALL_SUCCESS',
+        'filter': "exec_event_total > 0"
+	},
+    "EXEC_EVENT_SUCCESS": {
+        'parent_name': 'EXEC_EVENT_ATTEMPT',
+        'filter': "exec_event_success_total > 0"
+	},
+    "PIPELINE_ATTEMPT": {
+        'parent_name': 'EXEC_EVENT_SUCCESS',
+        'filter': "pipeline_runs_count_all > 0"
+	},
+    "PIPELINE_SUCCESS": {
+        'parent_name': 'PIPELINE_ATTEMPT',
+        'filter': "pipeline_runs_count_success > 0"
+	},
+    "ADD_OR_INSTALL_NON_GSG": {
+        'parent_name': 'PIPELINE_SUCCESS',
+        'filter': "non_gsg_add > 0"
+	},
+    "ADD_OR_INSTALL_NON_GSG_SUCCESS": {
+        'parent_name': 'ADD_OR_INSTALL_NON_GSG',
+        'filter': "non_gsg_add_success > 0"
+	},
+    "EXEC_NON_GSG": {
+        'parent_name': 'ADD_OR_INSTALL_NON_GSG_SUCCESS',
+        'filter': "non_gsg_exec > 0"
+	},
+    "EXEC_NON_GSG_SUCCESS": {
+        'parent_name': 'EXEC_NON_GSG',
+        'filter': "non_gsg_exec_success > 0"
+	},
+    "PIPELINE_NON_GSG": {
+        'parent_name': 'EXEC_NON_GSG_SUCCESS',
+        'filter': "non_gsg_pipeline > 0"
+	},
+    "PIPELINE_NON_GSG_SUCCESS": {
+        'parent_name': 'PIPELINE_NON_GSG',
+        'filter': "non_gsg_pipeline_success > 0"
+	},
+    "GREATER_1_DAY": {
+        'parent_name': 'PIPELINE_NON_GSG_SUCCESS',
+        'filter': "project_lifespan_hours >= 24"
+	},
+    "GREATER_7_DAY": {
+        'parent_name': 'GREATER_1_DAY',
+        'filter': "project_lifespan_hours >= (7*24)"
+	},
+    "ACTIVE_EXECUTION": {
+        'parent_name': 'GREATER_7_DAY',
+        'filter': "active_executions_count > 0"
+	},
+    "STILL_ACTIVE": {
+        'parent_name': 'ACTIVE_EXECUTION',
+        'filter': "is_currently_active = TRUE"
+	}
+	}
+%}
+
+WITH active_executions AS (
+
+    SELECT
+        project_id,
+        SUM(
+            CASE WHEN is_active_cli_execution THEN 1 END
+        ) AS active_executions_count
+    FROM {{ ref('fact_cli_executions') }}
+    GROUP BY 1
+),
+
+project_base AS (
+
+    SELECT
+        project_dim.*,
+        active_executions.active_executions_count,
+        DATE_TRUNC(WEEK, project_dim.project_first_event_at) AS cohort_week
+    FROM {{ ref('project_dim') }}
+    LEFT JOIN active_executions
+        ON project_dim.project_id = active_executions.project_id
+    WHERE project_dim.is_codespace_demo = TRUE
+
+),
+
+agg_base AS (
+    SELECT
+        cohort_week,
+        COUNT(
+            DISTINCT project_id
+        ) AS base_all,
+        {% for filter_name, attribs in mapping.items() %}
+        {{ compounding_funnel_filters(
+			loop.index,
+			filter_name,
+			mapping,
+			"COUNT(DISTINCT CASE WHEN TRUE",
+			"THEN project_id END)"
+		) }} AS {{ filter_name }}
+			{%- if not loop.last %},{% endif -%}
+		{% endfor %}
+    FROM project_base
+    GROUP BY 1
+)
+
+
+{% for filter_name, attribs in mapping.items() %}    
+
+{%- if not loop.first %}
+UNION ALL
+{% endif -%}
+
+SELECT
+    cohort_week,
+    '{{ loop.index }}' || '_' || '{{ filter_name }}' AS funnel_level,
+    {{ filter_name }} AS funnel_level_value,
+    {{ attribs.get('parent_name', 'base_all') }} AS parent_level_value,
+    base_all
+FROM agg_base
+
+{% endfor %}


### PR DESCRIPTION
Related to https://github.com/meltano/internal-data/issues/49. Mostly closes it out but the charts need to be replicated and pointed to this table.

- passes `options_obj` through to be used downstream
- parses out the init project_directory attribute
- uses the directory name to flag known paths like getting started guides and codespace demo
- I couldnt find an obvious way to flow this attribute through to the funnel model so we can toggle in Superset so I had to clone the model and filter for codespace demo projects. There might be a way to do it but right now I'm preaggregating the data to get it in a form that Superset's pivot table likes. We should consider exploring other options if we're going to want the funnels to be more flexible and dynamic.

cc @tayloramurphy @sbalnojan 