### PR TITLE
add simple hash to slack emails so they dont leave raw

### DIFF
--- a/data/transform/models/marts/community/slack_members_daily.sql
+++ b/data/transform/models/marts/community/slack_members_daily.sql
@@ -16,7 +16,7 @@ base AS (
 
     SELECT
         stg_slack__users.user_id,
-        stg_slack__users.email,
+        stg_slack__users.email_hash,
         stg_slack__users.email_domain,
         -- The slack bot was added on 2021-04-01. So we dont know the exact
         -- added date for user prior to that.

--- a/data/transform/models/marts/community/slack_new_members.sql
+++ b/data/transform/models/marts/community/slack_new_members.sql
@@ -14,7 +14,7 @@ WITH new_member_message AS (
 
 SELECT
     stg_slack__users.user_id,
-    stg_slack__users.email,
+    stg_slack__users.email_hash,
     stg_slack__users.email_domain,
     new_member_message.message_created_at,
     stg_slack__users.is_deleted

--- a/data/transform/models/staging/slack/stg_slack__users.sql
+++ b/data/transform/models/staging/slack/stg_slack__users.sql
@@ -29,7 +29,7 @@ renamed AS (
         is_bot,
         is_app_user,
         is_email_confirmed,
-        profile:email::STRING AS email,
+        MD5(profile:email::STRING) AS email_hash,
         SUBSTR(
             profile:email::STRING, CHARINDEX('@', profile:email::STRING) + 1
         ) AS email_domain,


### PR DESCRIPTION
closes https://github.com/meltano/internal-data/issues/47

A simple first step to limit the use of anything that might be sensitive. I acknowledge that a hash isnt the same as fully encrypting the value but its an easy step to obfuscated from anyone who might be viewing this non-raw data.

NOTE: Once this merges it also requires us to delete those 4 columns from prod tables. Reclone to dev environments.