### PR TITLE
stop truncating events older than 2 years

### DIFF
--- a/data/transform/models/marts/telemetry/base/cli_execs_blended.sql
+++ b/data/transform/models/marts/telemetry/base/cli_execs_blended.sql
@@ -15,9 +15,6 @@ INNER JOIN
         unstruct_exec_flattened.project_id = event_src_activation.project_id
 WHERE
     unstruct_exec_flattened.started_ts >= event_src_activation.sp_activate_date
-    AND unstruct_exec_flattened.started_ts >= DATEADD(
-        'month', -25, DATE_TRUNC('month', CURRENT_DATE)
-    )
 
 UNION ALL
 
@@ -38,9 +35,6 @@ WHERE
     -- Only count legacy structured events without context.
     -- Structured with context will be rolled up into unstructured
     AND stg_snowplow__events.contexts IS NULL
-    AND stg_snowplow__events.event_created_at >= DATEADD(
-        'month', -25, DATE_TRUNC('month', CURRENT_DATE)
-    )
 
 UNION ALL
 
@@ -58,7 +52,4 @@ LEFT JOIN
 WHERE
     (event_src_activation.sp_activate_date IS NULL
         OR stg_ga__cli_events.event_date < event_src_activation.sp_activate_date
-    )
-    AND stg_ga__cli_events.event_date >= DATEADD(
-        'month', -25, DATE_TRUNC('month', CURRENT_DATE)
     )

--- a/data/transform/models/marts/telemetry/base/unstructured_parsing/event_unstruct.sql
+++ b/data/transform/models/marts/telemetry/base/unstructured_parsing/event_unstruct.sql
@@ -19,9 +19,6 @@ WITH base AS (
         ):data AS event_data
     FROM {{ ref('stg_snowplow__events') }}
     WHERE contexts IS NOT NULL
-        AND event_created_at >= DATEADD(
-            'month', -25, DATE_TRUNC('month', CURRENT_DATE)
-        )
 
 )
 


### PR DESCRIPTION
Closes https://github.com/meltano/squared/issues/512

This was causing the tests to fail because more projects IDs were showing up in the raw tables than in the downstream tables. This is the first month where the dates exceeded the 25 month range.

After re-evaluating since this was implemented we still want all historical data otherwise we miss part of a projects usage attributes if they're outside the 2 year window. For example all their project attributes like total successful pipelines and first event date will get truncated and will always be "today - 25 months".

If we do want to re-implement this to save on query load we should rethink how to do it exactly. Potentially allowing us to filtering projects where their last event exceeds that window. We should still keep them in the staged data though, just filtering further down the line to reduce query time.