### PR TITLE
use views for staging and refresh only in CI deployments

### DIFF
--- a/.github/workflows/prod_deploy.yml
+++ b/.github/workflows/prod_deploy.yml
@@ -119,3 +119,4 @@ jobs:
     # Seed Production
     - run: meltano install utility dbt-snowflake
     - run: meltano run dbt-snowflake:run_dbt_artifacts dbt-snowflake:seed
+    - run: meltano run dbt-snowflake:materialize_views

--- a/data/orchestrate/orchestrators.meltano.yml
+++ b/data/orchestrate/orchestrators.meltano.yml
@@ -60,6 +60,7 @@ jobs:
 - name: slack_notifications
   tasks:
   - dbt-snowflake:run_slack_notifications
+  - dbt-snowflake:test_slack_notifications
   - tap-snowflake-singer-activity target-apprise
 
 - name: dbt_docs

--- a/data/transform/models/publish/slack_notifications/schema.yml
+++ b/data/transform/models/publish/slack_notifications/schema.yml
@@ -1,0 +1,14 @@
+version: 2
+
+models:
+  - name: slack_alerts
+    description: This table includes the message to be sent to Slack for the singer-ecosystem-activity channel.
+    columns:
+      - name: title
+        description: The Slack message title.
+        tests:
+          - not_null
+      - name: body
+        description: The body of the Slack message, in markdown format.
+        tests:
+          - not_null

--- a/data/transform/models/staging/github_meltano/stg_github__issues.sql
+++ b/data/transform/models/staging/github_meltano/stg_github__issues.sql
@@ -1,5 +1,3 @@
-{{ config(materialized='table') }}
-
 WITH source AS (
 
     SELECT

--- a/data/transform/models/staging/github_meltano/stg_github__pull_requests.sql
+++ b/data/transform/models/staging/github_meltano/stg_github__pull_requests.sql
@@ -1,5 +1,3 @@
-{{ config(materialized='table') }}
-
 WITH source AS (
 
     SELECT

--- a/data/transform/models/staging/github_meltano/stg_github__repositories.sql
+++ b/data/transform/models/staging/github_meltano/stg_github__repositories.sql
@@ -1,5 +1,3 @@
-{{ config(materialized='table') }}
-
 WITH source AS (
 
     SELECT

--- a/data/transform/models/staging/gitlab/stg_gitlab__issues.sql
+++ b/data/transform/models/staging/gitlab/stg_gitlab__issues.sql
@@ -1,5 +1,3 @@
-{{ config(materialized='table') }}
-
 WITH source AS (
 
     SELECT

--- a/data/transform/models/staging/gitlab/stg_gitlab__merge_requests.sql
+++ b/data/transform/models/staging/gitlab/stg_gitlab__merge_requests.sql
@@ -1,5 +1,3 @@
-{{ config(materialized='table') }}
-
 WITH source AS (
 
     SELECT

--- a/data/transform/models/staging/gitlab/stg_gitlab__projects.sql
+++ b/data/transform/models/staging/gitlab/stg_gitlab__projects.sql
@@ -1,5 +1,3 @@
-{{ config(materialized='table') }}
-
 WITH source AS (
 
     SELECT

--- a/data/transform/transformers.meltano.yml
+++ b/data/transform/transformers.meltano.yml
@@ -9,26 +9,26 @@ plugins:
           \ False, 'schema_list': []}\""
         description: Clones all production schemas in the PREP database that the user
           has access to.
-  
+
       run_dbt_artifacts: run --select dbt_artifacts.*
 
-      run_marts: run --select marts.* common.* --exclude staging.*,dbt_artifacts.*
-      test_marts: test --select marts.* common.* --exclude staging.*,dbt_artifacts.*
-  
+      run_marts: run --select marts.* common.* --exclude config.materialized:view
+      test_marts: test --select marts.* common.*
+
       run_staging_meltanohub: run --select staging.meltanohub.*
       run_snapshot_meltanohub: snapshot --select meltanohub.*
       test_source_meltanohub: test --select source:tap_meltanohub
       test_staging_meltanohub: test --select staging.meltanohub.*,test_type:generic
-  
+
       run_snapshot_spreadsheets_anywhere: snapshot --select spreadsheets_anywhere.*
       test_source_spreadsheets_anywhere: test --select source:tap_spreadsheets_anywhere
-  
+
       run_staging_snowplow: run --select staging.snowplow.*
       test_staging_snowplow: test --select staging.snowplow.*,test_type:generic
-  
+
       run_staging_github_search: run --select staging.github_search.*
       test_staging_github_search: test --select staging.github_search.*,test_type:generic
-  
+
       run_staging_github_meltano: run --select staging.github_meltano.*
       test_staging_github_meltano: test --select staging.github_meltano.*,test_type:generic
 
@@ -41,10 +41,13 @@ plugins:
       run_staging_google_analytics: run --select staging.google_analytics.*
       test_staging_google_analytics: test --select staging.google_analytics.*,test_type:generic
 
-      run_hub_metrics: run --select publish.meltano_hub.*
+      run_hub_metrics: run --select publish.meltano_hub.* --exclude config.materialized:view
       test_hub_metrics: test --select publish.meltano_hub.*
 
-      run_slack_notifications: run --select publish.slack_notifications.*
+      run_slack_notifications: run --select publish.slack_notifications.* --exclude config.materialized:view
+      test_slack_notifications: test --select publish.slack_notifications.*
+
+      materialize_views: run --select config.materialized:view
     config:
       account: epa06486
       database_raw: RAW


### PR DESCRIPTION
- consistently make all staging models views
- when we deploy in CI we should refresh our views, similar to seed. Then following that we dont need to keep rebuilding the views.
- add a test for slack notifications for consistency