### PR TITLE
use git url for private dbt package

### DIFF
--- a/data/transform/packages.yml
+++ b/data/transform/packages.yml
@@ -5,6 +5,6 @@ packages:
     version: 2.1.0
   # - package: dbt-labs/codegen
   #   version: 0.6.0
-  - git: "https://github.com/meltano/internal-data.git"
+  - git: "git@github.com:meltano/internal-data.git"
     revision: "main"
     subdirectory: "data"


### PR DESCRIPTION
Looks like the git url was still using http instead of ssh.