### PR TITLE
fix vpn script to not exit early

### DIFF
--- a/deploy/vpn/enroll_client.sh
+++ b/deploy/vpn/enroll_client.sh
@@ -10,7 +10,7 @@ set -o pipefail
 
 [ ! -x "$(command -v op)" ] && echo "The 1Password CLI must be installed: https://developer.1password.com/docs/cli/install-server/" && exit 1
 
-env | grep -e '^OP_SESSION_' > /dev/null
+op account get > /dev/null
 [ $? -ne 0 ] && echo "You must sign-in to the 1Password CLI by running: https://developer.1password.com/docs/cli/sign-in-manually" && exit 1
 
 # Exit early if the 1Password session token has expired


### PR DESCRIPTION
I ran this as part of https://github.com/meltano/internal-data/issues/59 but it kept exiting early with code 1 even though I had the CLI installed and was logged in. It looks like there an assumption that an env var is present once you've signed in but that doesnt show up in mine, maybe the CLI has changed since this script was written 🤷 . I think this should do what we want, checks to see if the user is logged in once we've confirmed they have the CLI installed.

@WillDaSilva wdyt?

PS: I cancelled the CI jobs because this doesnt change any of the tested `/data` project.