### PR TITLE
move github el out 1 hr and slack refresh all it needs

### DIFF
--- a/data/orchestrate/orchestrators.meltano.yml
+++ b/data/orchestrate/orchestrators.meltano.yml
@@ -36,7 +36,7 @@ schedules:
   job: github_search_el
 
 - name: github_meltano_el
-  interval: 0 6 * * *
+  interval: 0 7 * * *
   job: github_meltano_el
 
 - name: gitlab_el

--- a/data/transform/transformers.meltano.yml
+++ b/data/transform/transformers.meltano.yml
@@ -47,7 +47,7 @@ plugins:
       run_hub_metrics: run --select publish.meltano_hub.*
       test_hub_metrics: test --select publish.meltano_hub.*
 
-      run_slack_notifications: run --select publish.slack_notifications.*
+      run_slack_notifications: run --select +publish.slack_notifications.*
     config:
       account: epa06486
       database_raw: RAW


### PR DESCRIPTION
- github el sometimes has rate limiting issues, push meltano el out to the next hour when rate limits reset
- update slack notifications job to refresh dependencies in case it needs to be refreshed manually after data refresh