### PR TITLE
Reparse more bad events

### DIFF
--- a/data/transform/models/staging/snowplow/schema.yml
+++ b/data/transform/models/staging/snowplow/schema.yml
@@ -7,3 +7,15 @@ models:
         tests:
           - unique
           - not_null
+      - name: event_vendor
+        tests:
+          - not_null
+      - name: event_name
+        tests:
+          - not_null
+      - name: event_format
+        tests:
+          - not_null
+      - name: event_version
+        tests:
+          - not_null

--- a/data/transform/models/staging/snowplow/snowplow_bad_parsed.sql
+++ b/data/transform/models/staging/snowplow/snowplow_bad_parsed.sql
@@ -13,9 +13,50 @@ WITH reparse_1 AS (
         ]:schemaKey::string
         = 'iglu:com.meltano/environment_context/jsonschema/1-2-0'
 
+),
+
+reparse_2 AS (
+    -- Incident: exit_event incorrectly required not null exit_code
+    -- Affected versions 2.0.3 - 2.6.0
+    -- Related issues: https://github.com/meltano/meltano/issues/6243 and
+    -- https://github.com/meltano/meltano/pull/6244
+    SELECT
+        payload_enriched,
+        uploaded_at
+    FROM {{ ref('stg_snowplow__events_bad') }}
+    WHERE failure_message[
+            0
+        ]:schemaKey::string
+        = 'iglu:com.meltano/exit_event/jsonschema/1-0-0'
+        AND failure_message[
+            0
+        ]:error:dataReports[0]:message::string
+        = '$.exit_code: null found, integer expected'
+
+),
+
+reparse_3 AS (
+    -- Incident: events sent with schema name exceptions_context vs
+    -- exception_context as registered in Snowcat
+    -- Affected versions 2.0.1 - 2.0.2
+    -- Related issues: https://github.com/meltano/meltano/issues/6213 and
+    -- https://github.com/meltano/meltano/pull/6212
+    SELECT
+        uploaded_at,
+        REPLACE(
+            payload_enriched,
+            'iglu:com.meltano/exceptions_context/jsonschema/1-0-0',
+            'iglu:com.meltano/exception_context/jsonschema/1-0-0'
+        ) AS payload_enriched
+    FROM {{ ref('stg_snowplow__events_bad') }}
+    WHERE failure_message[
+            0
+        ]:schemaKey::string
+        = 'iglu:com.meltano/exceptions_context/jsonschema/1-0-0'
+
 )
 
-{% for cte_name in ['reparse_1'] %}
+{% for cte_name in ['reparse_1', 'reparse_2', 'reparse_3'] %}
 
 {%- if not loop.first %}
 UNION ALL

--- a/data/transform/models/staging/snowplow/snowplow_bad_parsed.sql
+++ b/data/transform/models/staging/snowplow/snowplow_bad_parsed.sql
@@ -202,26 +202,30 @@ SELECT -- noqa: L034
     PARSE_JSON(payload_enriched):derived_contexts::string AS derived_contexts,
     PARSE_JSON(payload_enriched):domain_sessionid::string AS domain_sessionid,
     collector_tstamp AS derived_tstamp,
-    SPLIT_PART(
-        SPLIT_PART(PARSE_JSON(unstruct_event):data:schema::string, ':', 2),
-        '/',
-        1
-    ) AS event_vendor,
-    SPLIT_PART(
-        SPLIT_PART(PARSE_JSON(unstruct_event):data:schema::string, ':', 2),
-        '/',
-        2
-    ) AS event_name,
-    SPLIT_PART(
-        SPLIT_PART(PARSE_JSON(unstruct_event):data:schema::string, ':', 2),
-        '/',
-        3
-    ) AS event_format,
-    SPLIT_PART(
-        SPLIT_PART(PARSE_JSON(unstruct_event):data:schema::string, ':', 2),
-        '/',
-        4
-    ) AS event_version,
+    CASE WHEN unstruct_event IS NULL THEN 'com.google.analytics' ELSE
+        SPLIT_PART(
+            SPLIT_PART(PARSE_JSON(unstruct_event):data:schema::string, ':', 2),
+            '/',
+            1
+        ) END AS event_vendor,
+    CASE WHEN unstruct_event IS NULL THEN 'event' ELSE
+        SPLIT_PART(
+            SPLIT_PART(PARSE_JSON(unstruct_event):data:schema::string, ':', 2),
+            '/',
+            2
+        ) END AS event_name,
+    CASE WHEN unstruct_event IS NULL THEN 'jsonschema' ELSE
+        SPLIT_PART(
+            SPLIT_PART(PARSE_JSON(unstruct_event):data:schema::string, ':', 2),
+            '/',
+            3
+        ) END AS event_format,
+    CASE WHEN unstruct_event IS NULL THEN '1-0-0' ELSE
+        SPLIT_PART(
+            SPLIT_PART(PARSE_JSON(unstruct_event):data:schema::string, ':', 2),
+            '/',
+            4
+        ) END AS event_version,
     PARSE_JSON(payload_enriched):event_fingerprint::string AS event_fingerprint,
     PARSE_JSON(payload_enriched):true_tstamp::string AS true_tstamp,
     uploaded_at

--- a/data/transform/models/staging/snowplow/stg_snowplow__events_bad.sql
+++ b/data/transform/models/staging/snowplow/stg_snowplow__events_bad.sql
@@ -17,7 +17,8 @@ SELECT
     ):detail:data:failure:timestamp::TIMESTAMP AS failure_timestamp,
     PARSE_JSON(jsontext):detail:data:payload:raw AS payload_raw,
     PARSE_JSON(jsontext):detail:data:payload:enriched AS payload_enriched,
-    PARSE_JSON(jsontext):detail:data:processor AS processor
+    PARSE_JSON(jsontext):detail:data:processor AS processor,
+    PARSE_JSON(payload_enriched):event_id::STRING AS event_id
     {% if env_var("MELTANO_ENVIRONMENT") == "cicd" %}
     FROM raw.snowplow.events_bad
     WHERE uploaded_at::TIMESTAMP >= DATEADD('day', -7, CURRENT_DATE)

--- a/data/transform/profiles/snowflake/profiles.yml
+++ b/data/transform/profiles/snowflake/profiles.yml
@@ -10,7 +10,7 @@ meltano:
   outputs:
     jigsaw:
       type: snowflake
-      threads: 2
+      threads: 6
       account: "{{ env_var('DBT_SNOWFLAKE_ACCOUNT') }}"
       user: "{{ env_var('DBT_SNOWFLAKE_USER') }}"
       password: "{{ env_var('SNOWFLAKE_PASSWORD') }}"
@@ -20,7 +20,7 @@ meltano:
       schema: "DEFAULT"
     userdev:
       type: snowflake
-      threads: 2
+      threads: 6
       account: "{{ env_var('DBT_SNOWFLAKE_ACCOUNT') }}"
       user: "{{ env_var('DBT_SNOWFLAKE_USER') }}"
       password: "{{ env_var('SNOWFLAKE_PASSWORD') }}"
@@ -30,7 +30,7 @@ meltano:
       schema: "DEFAULT"
     staging:
       type: snowflake
-      threads: 4
+      threads: 6
       account: "{{ env_var('DBT_SNOWFLAKE_ACCOUNT') }}"
       user: "{{ env_var('DBT_SNOWFLAKE_USER') }}"
       password: "{{ env_var('SNOWFLAKE_PASSWORD') }}"
@@ -50,7 +50,7 @@ meltano:
       schema: "DEFAULT"
     cicd:
       type: snowflake
-      threads: 4
+      threads: 6
       account: "{{ env_var('DBT_SNOWFLAKE_ACCOUNT') }}"
       user: "{{ env_var('DBT_SNOWFLAKE_USER') }}"
       password: "{{ env_var('SNOWFLAKE_PASSWORD') }}"

--- a/data/transform/tests/staging/snowplow/structured_events_schema.sql
+++ b/data/transform/tests/staging/snowplow/structured_events_schema.sql
@@ -1,0 +1,11 @@
+-- We hardcode google analytics schemas for reparsing bad events in
+-- `snowplow_bad_parsed` assuming theres only one event schema. If
+-- that changes we should be alerted.
+SELECT DISTINCT
+    event_vendor,
+    event_name,
+    event_format,
+    event_version
+FROM {{ ref('stg_snowplow__events') }}
+WHERE event_vendor = 'com.google.analytics'
+    AND event_version != '1-0-0'


### PR DESCRIPTION
Closes https://github.com/meltano/squared/issues/257

- reparses an issue where exception context was spelled wrong in 2 meltano releases. I transformed those records to match the expected naming and fed them back into the staging dbt models.
- reparses null exit_events which were valid but the schema was too strict and was later updated.