### PR TITLE
filter out non-cli events from custom parsing logic

### DIFF
--- a/data/transform/models/marts/telemetry/base/cli_execs_blended.sql
+++ b/data/transform/models/marts/telemetry/base/cli_execs_blended.sql
@@ -35,6 +35,7 @@ WHERE
     -- Only count legacy structured events without context.
     -- Structured with context will be rolled up into unstructured
     AND stg_snowplow__events.contexts IS NULL
+    AND stg_snowplow__events.app_id = 'meltano'
 
 UNION ALL
 

--- a/data/transform/models/marts/telemetry/base/unstructured_parsing/event_unstruct.sql
+++ b/data/transform/models/marts/telemetry/base/unstructured_parsing/event_unstruct.sql
@@ -19,6 +19,7 @@ WITH base AS (
         ):data AS event_data
     FROM {{ ref('stg_snowplow__events') }}
     WHERE contexts IS NOT NULL
+        AND app_id = 'meltano'
 
 )
 

--- a/data/transform/models/staging/snowplow/stg_snowplow__events.sql
+++ b/data/transform/models/staging/snowplow/stg_snowplow__events.sql
@@ -12,9 +12,6 @@ WITH blended_source AS (
 
         FROM raw.snowplow.events
         WHERE derived_tstamp::TIMESTAMP >= DATEADD('day', -7, CURRENT_DATE)
-            -- only meltano events. For the first ~6 months no app_id was
-            -- sent from Meltano. So nulls are from meltano.
-            AND COALESCE(app_id, 'meltano') = 'meltano'
         {% else %}
 
         FROM {{ source('snowplow', 'events') }}
@@ -70,7 +67,9 @@ clean_new_source AS (
 renamed AS (
 
     SELECT -- noqa: L034
-        app_id,
+        -- only meltano events. For the first ~6 months no app_id was
+        -- sent from Meltano. So nulls are from meltano.
+        COALESCE(app_id, 'meltano') AS app_id,
         platform,
         etl_tstamp::TIMESTAMP AS etl_enriched_at,
         collector_tstamp::TIMESTAMP AS collector_received_at,


### PR DESCRIPTION
2 tests were failing in prod since we added page_view events to snowplow. We werent' explicitly filtering for app_id in the models that do parsing of our custom events. This fixes that.