### PR TITLE
add project org override mechanism based on seed file

### DIFF
--- a/data/transform/models/marts/telemetry/base/project_org_mapping.sql
+++ b/data/transform/models/marts/telemetry/base/project_org_mapping.sql
@@ -7,7 +7,11 @@ WITH base AS (
     FROM {{ ref('cli_executions_base') }}
     LEFT JOIN {{ ref('ip_address_dim') }}
         ON cli_executions_base.ip_address_hash = ip_address_dim.ip_address_hash
+    LEFT JOIN {{ ref('internal_data', 'project_org_manual') }}
+        ON cli_executions_base.project_id = project_org_manual.project_id
     WHERE ip_address_dim.org_name IS NOT NULL
+        -- Exclude manual override of Leadmagic
+        AND project_org_manual.project_id IS NULL
 
 ),
 
@@ -23,7 +27,16 @@ single_org_projects AS (
 
 SELECT DISTINCT
     base.org_name,
-    base.project_id
+    base.project_id,
+    'LEADMAGIC' AS org_source
 FROM base
 INNER JOIN single_org_projects
     ON base.project_id = single_org_projects.project_id
+
+UNION ALL
+
+SELECT DISTINCT
+    org_name,
+    project_id,
+    'MANUAL' AS org_source
+FROM {{ ref('internal_data', 'project_org_manual') }}

--- a/data/transform/models/marts/telemetry/base/schema.yml
+++ b/data/transform/models/marts/telemetry/base/schema.yml
@@ -143,6 +143,12 @@ models:
         tests:
           - not_null
           - unique
+      - name: org_source
+        description: The unique plugin execution ID.
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['MANUAL', 'LEADMAGIC']
 
   - name: ip_org_mapping_lm
     description: A mapping of projects to the organization that we expect they're part of. This is currently based on attributes provided by LeadMagic.


### PR DESCRIPTION
Closes https://github.com/meltano/internal-data/issues/23

Uses seed data from https://github.com/meltano/internal-data/pull/77 to manually override project org names.