### PR TITLE
Chore: fix meltano install in devcontainers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,77 +1,80 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/python
 {
-	"name": "Python 3",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/python:0-3.9",
+    "name": "Python 3",
+    // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+    "image": "mcr.microsoft.com/devcontainers/python:0-3.9",
 
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	"features": {
+    // Features to add to the dev container. More info: https://containers.dev/features.
+    "features": {
         "github-cli": {
             "version": "latest"
         },
         "ghcr.io/devcontainers/features/docker-in-docker:1": {
             "version": "latest"
+        },
+		"ghcr.io/devcontainers-contrib/features/meltano": {},
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
+		"ghcr.io/devcontainers/features/node:1": {},
+		"ghcr.io/devcontainers-contrib/features/meltano:2": {}
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                // BYO Settings:
+                "EditorConfig.EditorConfig",
+
+                // dbt and Meltano Support:
+                "innoverio.vscode-dbt-power-user",
+                "bastienboutonnet.vscode-dbt",
+                "z3z1ma.meltano-power-user",
+                "dorzey.vscode-sqlfluff",
+                "redhat.vscode-yaml",
+        
+                // git UX improvements:
+                "github.vscode-pull-request-github",
+                "eamodio.gitlens",
+                "vivaxy.vscode-conventional-commits",
+
+                // SQL Tools Database Explorer:
+                "mtxr.sqltools",
+                "mtxr.sqltools-driver-sqlite",
+                "RandomFractalsInc.duckdb-sql-tools",
+                "koszti.snowflake-driver-for-sqltools",
+
+                // Other Data Tools:
+                "mechatroner.rainbow-csv",
+
+                // Python Editing Support:
+                "ms-python.python",
+                "ms-python.black-formatter"
+            ],
+            "settings": {
+                "python.pythonPath": "/usr/local/bin/python",
+                "dbt.profilesDirOverride": "./data/transform/profiles/snowflake/",
+                "files.associations": {
+                    "*.sql": "jinja-sql"
+                }
+                // any other settings go here
+            }
+        }, 
+        "codespaces": {
+            "openFiles": [
+                "./README.md"
+            ]
         }
-	},
-	"customizations": {
-		"vscode": {
-			"extensions": [
-				// BYO Settings:
-				"EditorConfig.EditorConfig",
+    },
+    "postCreateCommand": "meltano install"
 
-				// dbt and Meltano Support:
-				"innoverio.vscode-dbt-power-user",
-				"bastienboutonnet.vscode-dbt",
-				"z3z1ma.meltano-power-user",
-				"dorzey.vscode-sqlfluff",
-				"redhat.vscode-yaml",
-		
-				// git UX improvements:
-				"github.vscode-pull-request-github",
-				"eamodio.gitlens",
-				"vivaxy.vscode-conventional-commits",
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
 
-				// SQL Tools Database Explorer:
-				"mtxr.sqltools",
-				"mtxr.sqltools-driver-sqlite",
-				"RandomFractalsInc.duckdb-sql-tools",
-				"koszti.snowflake-driver-for-sqltools",
+    // Use 'postCreateCommand' to run commands after the container is created.
+    // "postCreateCommand": "pip3 install --user -r requirements.txt",
 
-				// Other Data Tools:
-				"mechatroner.rainbow-csv",
+    // Configure tool-specific properties.
+    // "customizations": {},
 
-				// Python Editing Support:
-				"ms-python.python",
-				"ms-python.black-formatter"
-			],
-			"settings": {
-				"python.pythonPath": "/usr/local/bin/python",
-				"dbt.profilesDirOverride": "./data/transform/profiles/snowflake/",
-				"files.associations": {
-					"*.sql": "jinja-sql"
-				}
-				// any other settings go here
-			}
-		}, 
-		"codespaces": {
-			"openFiles": [
-				"./README.md"
-			]
-		}
-	},
-	"postCreateCommand": "meltano install",
-
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "pip3 install --user -r requirements.txt",
-
-	// Configure tool-specific properties.
-	// "customizations": {},
-
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
+    // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+    // "remoteUser": "root"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,77 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+	"name": "Python 3",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/python:0-3.9",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	"features": {
+        "github-cli": {
+            "version": "latest"
+        },
+        "ghcr.io/devcontainers/features/docker-in-docker:1": {
+            "version": "latest"
+        }
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				// BYO Settings:
+				"EditorConfig.EditorConfig",
+
+				// dbt and Meltano Support:
+				"innoverio.vscode-dbt-power-user",
+				"bastienboutonnet.vscode-dbt",
+				"z3z1ma.meltano-power-user",
+				"dorzey.vscode-sqlfluff",
+				"redhat.vscode-yaml",
+		
+				// git UX improvements:
+				"github.vscode-pull-request-github",
+				"eamodio.gitlens",
+				"vivaxy.vscode-conventional-commits",
+
+				// SQL Tools Database Explorer:
+				"mtxr.sqltools",
+				"mtxr.sqltools-driver-sqlite",
+				"RandomFractalsInc.duckdb-sql-tools",
+				"koszti.snowflake-driver-for-sqltools",
+
+				// Other Data Tools:
+				"mechatroner.rainbow-csv",
+
+				// Python Editing Support:
+				"ms-python.python",
+				"ms-python.black-formatter"
+			],
+			"settings": {
+				"python.pythonPath": "/usr/local/bin/python",
+				"dbt.profilesDirOverride": "./data/transform/profiles/snowflake/",
+				"files.associations": {
+					"*.sql": "jinja-sql"
+				}
+				// any other settings go here
+			}
+		}, 
+		"codespaces": {
+			"openFiles": [
+				"./README.md"
+			]
+		}
+	},
+	"postCreateCommand": "meltano install",
+
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "pip3 install --user -r requirements.txt",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/python
 {
-    "name": "Python 3",
+    "name": "Meltano Devcontainer",
     // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
     "image": "mcr.microsoft.com/devcontainers/python:0-3.9",
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -64,7 +64,7 @@
             ]
         }
     },
-    "postCreateCommand": "meltano install"
+    "postStartCommand": "meltano --cwd=./data install --paralellism=4"
 
     // Use 'forwardPorts' to make a list of ports inside the container available locally.
     // "forwardPorts": [],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,10 +13,10 @@
         "ghcr.io/devcontainers/features/docker-in-docker:1": {
             "version": "latest"
         },
-		"ghcr.io/devcontainers-contrib/features/meltano": {},
-		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
-		"ghcr.io/devcontainers/features/node:1": {},
-		"ghcr.io/devcontainers-contrib/features/meltano:2": {}
+        "ghcr.io/devcontainers-contrib/features/meltano": {},
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+        "ghcr.io/devcontainers/features/node:1": {},
+        "ghcr.io/devcontainers-contrib/features/meltano:2": {}
     },
     "customizations": {
         "vscode": {
@@ -30,7 +30,7 @@
                 "z3z1ma.meltano-power-user",
                 "dorzey.vscode-sqlfluff",
                 "redhat.vscode-yaml",
-        
+
                 // git UX improvements:
                 "github.vscode-pull-request-github",
                 "eamodio.gitlens",
@@ -57,7 +57,7 @@
                 }
                 // any other settings go here
             }
-        }, 
+        },
         "codespaces": {
             "openFiles": [
                 "./README.md"


### PR DESCRIPTION
This update fixes the `meltano install` command that previously was not working properly.

I've maxed to parallelism 4 to avoid crashing Docker - which happened to me on the first attempt.
