### PR TITLE
Speed up CI

### DIFF
--- a/.github/workflows/prod_deploy.yml
+++ b/.github/workflows/prod_deploy.yml
@@ -131,4 +131,5 @@ jobs:
     - run: pip install -r requirements.txt
     # Seed Production
     - run: meltano install utility dbt-snowflake
-    - run: meltano run dbt-snowflake:run_dbt_artifacts dbt-snowflake:seed
+    - run: meltano run dbt-snowflake:run_dbt_artifacts
+    - run: meltano invoke dbt-snowflake seed --full-refresh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,8 @@ jobs:
           ssh-private-key: ${{ secrets.GIT_SSH_PRIVATE_KEY }}
     # Run Test
     - run: meltano install utilities sqlfluff dbt-snowflake
-    - run: meltano run dbt-snowflake:deps sqlfluff:lint
+    - run: meltano run dbt-snowflake:deps
+    - run: meltano invoke sqlfluff lint $(python sqlfluff_file_changes.py)
 
   dbt_seed:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,6 @@ jobs:
         python-version: '3.8'
         cache: 'pip'
     - run: pip install -r requirements.txt
-    - run: echo "DEFAULT_START_DATE=$(date +'%Y-%m-%d' -d '1 day ago')" >> $GITHUB_ENV
     - run: echo "${{secrets.MELTANO_ENV_FILE }}" > .env 
     # Airflow
     - run: meltano install utility airflow
@@ -47,7 +46,6 @@ jobs:
         python-version: '3.8'
         cache: 'pip'
     - run: pip install -r requirements.txt
-    - run: echo "DEFAULT_START_DATE=$(date +'%Y-%m-%d' -d '1 day ago')" >> $GITHUB_ENV
     - run: echo "${{secrets.MELTANO_ENV_FILE }}" > .env
     # Add SSH key for accessing private dbt package repo
     - uses: webfactory/ssh-agent@v0.7.0
@@ -74,7 +72,6 @@ jobs:
         python-version: '3.8'
         cache: 'pip'
     - run: pip install -r requirements.txt
-    - run: echo "DEFAULT_START_DATE=$(date +'%Y-%m-%d' -d '1 day ago')" >> $GITHUB_ENV
     - run: echo "${{secrets.MELTANO_ENV_FILE }}" > .env
     # Add SSH key for accessing private dbt package repo
     - uses: webfactory/ssh-agent@v0.7.0
@@ -105,7 +102,9 @@ jobs:
         python-version: '3.8'
         cache: 'pip'
     - run: pip install -r requirements.txt
-    - run: echo "DEFAULT_START_DATE=$(date +'%Y-%m-%d' -d '1 day ago')" >> $GITHUB_ENV
+    - run: echo "DEFAULT_START_DATE_1D=$(date +'%Y-%m-%d %H:%M:%S' -d '24 hours ago')" >> $GITHUB_ENV
+    - run: echo "DEFAULT_START_DATE_4HR=$(date +'%Y-%m-%d %H:%M:%S' -d '4 hours ago')" >> $GITHUB_ENV
+    - run: echo "DEFAULT_START_DATE_2HR=$(date +'%Y-%m-%d %H:%M:%S' -d '2 hours ago')" >> $GITHUB_ENV
     - run: echo "${{secrets.MELTANO_ENV_FILE }}" > .env
     # Add SSH key for accessing private dbt package repo
     - uses: webfactory/ssh-agent@v0.7.0
@@ -134,7 +133,6 @@ jobs:
         python-version: '3.8'
         cache: 'pip'
     - run: pip install -r requirements.txt
-    - run: echo "DEFAULT_START_DATE=$(date +'%Y-%m-%d' -d '1 day ago')" >> $GITHUB_ENV
     - run: echo "${{secrets.MELTANO_ENV_FILE }}" > .env
     # Add SSH key for accessing private dbt package repo
     - uses: webfactory/ssh-agent@v0.7.0
@@ -162,7 +160,6 @@ jobs:
         python-version: '3.8'
         cache: 'pip'
     - run: pip install -r requirements.txt
-    - run: echo "DEFAULT_START_DATE=$(date +'%Y-%m-%d' -d '1 day ago')" >> $GITHUB_ENV
     - run: echo "${{secrets.MELTANO_ENV_FILE }}" > .env
     # Add SSH key for accessing private dbt package repo
     - uses: webfactory/ssh-agent@v0.7.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,7 +103,8 @@ jobs:
         python-version: '3.8'
         cache: 'pip'
     - run: pip install -r requirements.txt
-    - run: echo "DEFAULT_START_DATE_1D=$(date +'%Y-%m-%d %H:%M:%S' -d '24 hours ago')" >> $GITHUB_ENV
+    - run: echo "DEFAULT_START_DATE_1D=$(date +'%Y-%m-%d' -d '1 day ago')" >> $GITHUB_ENV
+    - run: echo "DEFAULT_START_DATE_24HR=$(date +'%Y-%m-%d %H:%M:%S' -d '24 hours ago')" >> $GITHUB_ENV
     - run: echo "DEFAULT_START_DATE_4HR=$(date +'%Y-%m-%d %H:%M:%S' -d '4 hours ago')" >> $GITHUB_ENV
     - run: echo "DEFAULT_START_DATE_2HR=$(date +'%Y-%m-%d %H:%M:%S' -d '2 hours ago')" >> $GITHUB_ENV
     - run: echo "${{secrets.MELTANO_ENV_FILE }}" > .env

--- a/data/.sqlfluff
+++ b/data/.sqlfluff
@@ -5,6 +5,8 @@ templater = dbt
 output_line_length = 80
 ignore_templated_areas = True
 runaway_limit = 100
+# Bug https://github.com/sqlfluff/sqlfluff/issues/4188
+exclude_rules = L071
 
 [sqlfluff:templater:dbt]
 project_dir = transform

--- a/data/environments/cicd.meltano.yml
+++ b/data/environments/cicd.meltano.yml
@@ -5,29 +5,29 @@ environments:
       extractors:
       - name: tap-cloudwatch
         config:
-          start_date: ${DEFAULT_START_DATE}
+          start_date: ${DEFAULT_START_DATE_2HR}
       - name: tap-slack
         config:
-          start_date: ${DEFAULT_START_DATE}
+          start_date: ${DEFAULT_START_DATE_4HR}
       - name: tap-slack-public
         config:
-          start_date: ${DEFAULT_START_DATE}
+          start_date: ${DEFAULT_START_DATE_4HR}
       - name: tap-google-analytics
         config:
-          start_date: ${DEFAULT_START_DATE}
+          start_date: ${DEFAULT_START_DATE_1D}
       - name: tap-gitlab
         config:
           groups: meltano
-          start_date: ${DEFAULT_START_DATE}
+          start_date: ${DEFAULT_START_DATE_1D}
       - name: tap-github
         config:
-          start_date: ${DEFAULT_START_DATE}
+          start_date: ${DEFAULT_START_DATE_1D}
       - name: tap-github-meltano
         config:
-          start_date: ${DEFAULT_START_DATE}
+          start_date: ${DEFAULT_START_DATE_1D}
       - name: tap-github-search
         config:
-          start_date: ${DEFAULT_START_DATE}
+          start_date: ${DEFAULT_START_DATE_1D}
           searches:
           # In CI we dont search forks and limit orgs to save time and requests
           - name: tap non-forks
@@ -104,6 +104,6 @@ environments:
           warehouse: CICD
   env:
     # Required to be set in environment
-    # DEFAULT_START_DATE: "2022-04-01"
+    # DEFAULT_START_DATE_1D: "2023-02-10 01:00:00"
     AIRFLOW__CORE__PLUGINS_FOLDER: $MELTANO_PROJECT_ROOT/orchestrate/plugins_local
     AIRFLOW_VAR_OPERATOR_TYPE: bash

--- a/data/environments/cicd.meltano.yml
+++ b/data/environments/cicd.meltano.yml
@@ -18,16 +18,16 @@ environments:
       - name: tap-gitlab
         config:
           groups: meltano
-          start_date: ${DEFAULT_START_DATE_1D}
+          start_date: ${DEFAULT_START_DATE_24HR}
       - name: tap-github
         config:
-          start_date: ${DEFAULT_START_DATE_1D}
+          start_date: ${DEFAULT_START_DATE_24HR}
       - name: tap-github-meltano
         config:
-          start_date: ${DEFAULT_START_DATE_1D}
+          start_date: ${DEFAULT_START_DATE_24HR}
       - name: tap-github-search
         config:
-          start_date: ${DEFAULT_START_DATE_1D}
+          start_date: ${DEFAULT_START_DATE_24HR}
           searches:
           # In CI we dont search forks and limit orgs to save time and requests
           - name: tap non-forks

--- a/data/sqlfluff_file_changes.py
+++ b/data/sqlfluff_file_changes.py
@@ -1,0 +1,50 @@
+"""
+    This script compares the current branch to main in order to get a list of SQL
+    files that changed and should be considered for linting.
+"""
+import subprocess
+import os
+import sys
+
+# These could indicate a change to the overall settings
+# or version so all files should be considered
+SQLFLUFF_FILES = [
+    ".sqlfluff",
+    ".sqlfluffignore",
+    "utilities.meltano.yml",
+]
+
+
+output = subprocess.run(
+    ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+    capture_output=True,
+    text=True
+)
+branch_name = output.stdout.replace("\n", "")
+output = subprocess.run(
+    ["git", "rev-parse", "--show-toplevel"],
+    capture_output=True,
+    text=True
+)
+base_path = output.stdout.replace("\n", "")
+output = subprocess.run(
+    ["git", "diff", "--name-status", f"main..{branch_name}"],
+    capture_output=True,
+    text=True
+)
+changed_files_raw = output.stdout
+changed_files_list = changed_files_raw.split("\n")
+
+changed_files = []
+all_flag = False
+for changed_file in changed_files_list:
+    if not changed_file:
+        continue
+    action = changed_file.split("\t")[0]
+    file_path = changed_file.split("\t")[1]
+    if action == "M" and file_path.endswith(".sql"):
+        changed_files.append(f"{base_path}/{file_path}")
+    if os.path.basename(file_path) in SQLFLUFF_FILES:
+        sys.exit(0)
+
+print(" ".join(changed_files))

--- a/data/transform/models/common/date_dim.sql
+++ b/data/transform/models/common/date_dim.sql
@@ -1,6 +1,6 @@
 WITH date_spine AS (
 
-  {{ dbt_utils.date_spine(
+{{ dbt_utils.date_spine(
       start_date="to_date('12/01/2015', 'mm/dd/yyyy')",
       datepart="day",
       end_date="dateadd(year, 40, current_date)"

--- a/data/transform/models/marts/telemetry/base/structured_parsing/cmd_parsed_add_remove.sql
+++ b/data/transform/models/marts/telemetry/base/structured_parsing/cmd_parsed_add_remove.sql
@@ -3,10 +3,10 @@ WITH prep AS (
         unique_commands.command,
         args_parsed.args,
         args_parsed.environment,
+        GET(unique_commands.split_parts, 2)::STRING AS plugin_type,
         'meltano ' || GET(
             SPLIT(unique_commands.command, ' '), 1
         )::STRING AS command_category,
-        GET(unique_commands.split_parts, 2)::STRING AS plugin_type,
         CASE
             WHEN
                 GET(

--- a/data/transform/models/marts/telemetry/base/structured_parsing/cmd_parsed_elt.sql
+++ b/data/transform/models/marts/telemetry/base/structured_parsing/cmd_parsed_elt.sql
@@ -3,13 +3,13 @@ SELECT
     unique_commands.command_category,
     args_parsed.args AS args,
     args_parsed.environment,
+    [
+        unique_commands.split_part_3, unique_commands.split_part_4
+    ]::ARRAY AS singer_plugins,
     COALESCE(
         unique_commands.command LIKE '%--transform run%'
         OR unique_commands.command LIKE '%--transform only%',
-        FALSE) AS dbt_run,
-    [
-        unique_commands.split_part_3, unique_commands.split_part_4
-    ]::ARRAY AS singer_plugins
+        FALSE) AS dbt_run
 FROM {{ ref('unique_commands') }}
 LEFT JOIN
     {{ ref('args_parsed') }} ON unique_commands.command = args_parsed.command

--- a/data/transform/models/marts/telemetry/base/structured_parsing/cmd_parsed_run.sql
+++ b/data/transform/models/marts/telemetry/base/structured_parsing/cmd_parsed_run.sql
@@ -56,9 +56,9 @@ _mappers AS (
     INNER JOIN
         target_pairs AS t2 ON
             target_pairs.command
-            = t2.command AND target_pairs.plugin_index >
-            t2.plugin_index AND target_pairs.plugin_index <
-            t2.target_pair_index
+            = t2.command AND target_pairs.plugin_index
+            > t2.plugin_index AND target_pairs.plugin_index
+            < t2.target_pair_index
 ),
 
 meltano_run AS (

--- a/data/transform/models/marts/telemetry/base/unstructured_parsing/context_plugins.sql
+++ b/data/transform/models/marts/telemetry/base/unstructured_parsing/context_plugins.sql
@@ -26,9 +26,9 @@ base_parsed AS (
     SELECT
         base.event_id,
         base.schema_name,
+        (base.context_index - min_index.first_index)::STRING AS plugin_index,
         SPLIT_PART(base.schema_name, '/', -1) AS schema_version,
-        base.context:data:plugins AS plugin_block,
-        (base.context_index - min_index.first_index)::STRING AS plugin_index
+        base.context:data:plugins AS plugin_block
     FROM base
     LEFT JOIN min_index ON base.event_id = min_index.event_id
 

--- a/data/transform/models/marts/telemetry/base/unstructured_parsing/plugin_executions_block.sql
+++ b/data/transform/models/marts/telemetry/base/unstructured_parsing/plugin_executions_block.sql
@@ -1,3 +1,5 @@
+-- SQLFluff fails because dbt_utils casts differently then us. Ignore for file.
+-- noqa: disable=L067
 WITH base AS (
 
     SELECT

--- a/data/transform/models/marts/telemetry/base/unstructured_parsing/unstruct_plugin_executions.sql
+++ b/data/transform/models/marts/telemetry/base/unstructured_parsing/unstruct_plugin_executions.sql
@@ -1,3 +1,5 @@
+-- SQLFluff fails because dbt_utils casts differently then us. Ignore for file.
+-- noqa: disable=L067
 WITH base AS (
     SELECT
         unstructured_executions.*,

--- a/data/transform/models/marts/telemetry/project_plugins.sql
+++ b/data/transform/models/marts/telemetry/project_plugins.sql
@@ -81,5 +81,5 @@ SELECT
     plugin_categories_7d,
     plugin_categories_28d / NULLIF(projects_28d, 0) AS app_28d,
     plugin_categories_14d / NULLIF(projects_14d, 0) AS app_14d,
-    plugin_categories_7d / NULLIF( projects_7d, 0) AS app_7d
+    plugin_categories_7d / NULLIF(projects_7d, 0) AS app_7d
 FROM plugins_per_project

--- a/data/transform/models/staging/github_search/stg_github_search__issues_base.sql
+++ b/data/transform/models/staging/github_search/stg_github_search__issues_base.sql
@@ -32,13 +32,13 @@ renamed AS (
         closed_at AS closed_at_ts,
         locked AS is_locked,
         type AS issue_type,
-        COALESCE(comments, 0) AS comment_count,
-        COALESCE(reactions:total_count::INT, 0) AS reactions_count,
         user:id::INT AS author_id,
         user:login::STRING AS author_username,
-        COALESCE(user:type::STRING = 'Bot', FALSE) AS is_bot_user,
         assignee:id::INT AS assignee_id,
-        assignee:login::STRING AS assignee_username
+        assignee:login::STRING AS assignee_username,
+        COALESCE(comments, 0) AS comment_count,
+        COALESCE(reactions:total_count::INT, 0) AS reactions_count,
+        COALESCE(user:type::STRING = 'Bot', FALSE) AS is_bot_user
     FROM source
     WHERE row_num = 1
 

--- a/data/transform/models/staging/github_search/stg_github_search__pull_requests.sql
+++ b/data/transform/models/staging/github_search/stg_github_search__pull_requests.sql
@@ -37,11 +37,11 @@ renamed AS (
         draft AS is_draft,
         user:id::INT AS author_id,
         user:login::STRING AS author_username,
-        COALESCE(user:type::STRING = 'Bot', FALSE) AS is_bot_user,
         assignee:id::INT AS assignee_id,
         assignee:login::STRING AS assignee_username,
         head:ref::STRING AS head_branch_name,
-        base:ref::STRING AS base_branch_name
+        base:ref::STRING AS base_branch_name,
+        COALESCE(user:type::STRING = 'Bot', FALSE) AS is_bot_user
     FROM source
     WHERE row_num = 1
 

--- a/data/transform/models/staging/slack/stg_slack__messages.sql
+++ b/data/transform/models/staging/slack/stg_slack__messages.sql
@@ -1,3 +1,5 @@
+-- SQLFluff fails because dbt_utils casts differently then us. Ignore for file.
+-- noqa: disable=L067
 WITH source AS (
 
     SELECT

--- a/data/transform/models/staging/slack/stg_slack__threads.sql
+++ b/data/transform/models/staging/slack/stg_slack__threads.sql
@@ -1,3 +1,5 @@
+-- SQLFluff fails because dbt_utils casts differently then us. Ignore for file.
+-- noqa: disable=L067
 WITH source AS (
 
     SELECT

--- a/data/transform/models/staging/slack/stg_slack__users.sql
+++ b/data/transform/models/staging/slack/stg_slack__users.sql
@@ -29,11 +29,11 @@ renamed AS (
         is_bot,
         is_app_user,
         is_email_confirmed,
+        profile:title::STRING AS title,
         MD5(profile:email::STRING) AS email_hash,
         SUBSTR(
             profile:email::STRING, CHARINDEX('@', profile:email::STRING) + 1
         ) AS email_domain,
-        profile:title::STRING AS title,
         TO_TIMESTAMP_NTZ(updated::INT) AS updated_at
     FROM source
     WHERE row_num = 1

--- a/data/transform/models/staging/snowplow/stg_snowplow__events.sql
+++ b/data/transform/models/staging/snowplow/stg_snowplow__events.sql
@@ -11,7 +11,7 @@ WITH blended_source AS (
         {% if env_var("MELTANO_ENVIRONMENT") == "cicd" %}
 
         FROM raw.snowplow.events
-        WHERE derived_tstamp::TIMESTAMP >= DATEADD('day', -7, CURRENT_DATE)
+        WHERE derived_tstamp::TIMESTAMP >= DATEADD('day', -3, CURRENT_DATE)
         {% else %}
 
         FROM {{ source('snowplow', 'events') }}

--- a/data/transform/models/staging/snowplow/stg_snowplow__events_bad.sql
+++ b/data/transform/models/staging/snowplow/stg_snowplow__events_bad.sql
@@ -13,7 +13,7 @@ SELECT
     PARSE_JSON(
         jsontext
     ):detail:data:failure:timestamp::TIMESTAMP AS failure_timestamp,
-    PARSE_JSON(payload_enriched):event_id::STRING AS event_id,
+    PARSE_JSON(jsontext):detail:data:payload:enriched:event_id::STRING AS event_id,
     PARSE_JSON(jsontext):resources AS resources,
     PARSE_JSON(jsontext):detail:data:failure:messages AS failure_message,
     PARSE_JSON(jsontext):detail:data:payload:raw AS payload_raw,

--- a/data/transform/models/staging/snowplow/stg_snowplow__events_bad.sql
+++ b/data/transform/models/staging/snowplow/stg_snowplow__events_bad.sql
@@ -13,7 +13,9 @@ SELECT
     PARSE_JSON(
         jsontext
     ):detail:data:failure:timestamp::TIMESTAMP AS failure_timestamp,
-    PARSE_JSON(jsontext):detail:data:payload:enriched:event_id::STRING AS event_id,
+    PARSE_JSON(
+        jsontext
+    ):detail:data:payload:enriched:event_id::STRING AS event_id,
     PARSE_JSON(jsontext):resources AS resources,
     PARSE_JSON(jsontext):detail:data:failure:messages AS failure_message,
     PARSE_JSON(jsontext):detail:data:payload:raw AS payload_raw,

--- a/data/transform/models/staging/snowplow/stg_snowplow__events_bad.sql
+++ b/data/transform/models/staging/snowplow/stg_snowplow__events_bad.sql
@@ -2,23 +2,23 @@ SELECT
     uploaded_at,
     PARSE_JSON(jsontext):id::STRING AS id,
     PARSE_JSON(jsontext):account::STRING AS account_name,
-    PARSE_JSON(jsontext):resources AS resources,
     PARSE_JSON(jsontext):time::TIMESTAMP AS event_time,
     PARSE_JSON(jsontext):source::STRING AS source,
     PARSE_JSON(jsontext):region::STRING AS region,
     PARSE_JSON(jsontext):version::STRING AS event_version,
     PARSE_JSON(jsontext):detail:schema::STRING AS failure_schema,
-    PARSE_JSON(jsontext):detail:data:failure:messages AS failure_message,
     PARSE_JSON(
         jsontext
     ):detail:data:failure:messages[0]:error:error::STRING AS error,
     PARSE_JSON(
         jsontext
     ):detail:data:failure:timestamp::TIMESTAMP AS failure_timestamp,
+    PARSE_JSON(payload_enriched):event_id::STRING AS event_id,
+    PARSE_JSON(jsontext):resources AS resources,
+    PARSE_JSON(jsontext):detail:data:failure:messages AS failure_message,
     PARSE_JSON(jsontext):detail:data:payload:raw AS payload_raw,
     PARSE_JSON(jsontext):detail:data:payload:enriched AS payload_enriched,
-    PARSE_JSON(jsontext):detail:data:processor AS processor,
-    PARSE_JSON(payload_enriched):event_id::STRING AS event_id
+    PARSE_JSON(jsontext):detail:data:processor AS processor
     {% if env_var("MELTANO_ENVIRONMENT") == "cicd" %}
     FROM raw.snowplow.events_bad
     WHERE uploaded_at::TIMESTAMP >= DATEADD('day', -7, CURRENT_DATE)

--- a/data/transform/snapshots/meltanohub/snapshot_meltanohub_plugins.sql
+++ b/data/transform/snapshots/meltanohub/snapshot_meltanohub_plugins.sql
@@ -1,14 +1,12 @@
 {% snapshot snapshot_meltanohub_plugins %}
 
-    {{
-        config(
-          target_schema=generate_schema_name('snapshot'),
-          strategy='check',
-          unique_key='id',
-          check_cols='all',
-          invalidate_hard_deletes=True
-        )
-    }}
+{{ config(
+        target_schema=generate_schema_name('snapshot'),
+        strategy='check',
+        unique_key='id',
+        check_cols='all',
+        invalidate_hard_deletes=True
+    ) }}
 
     WITH source AS (
 

--- a/data/transform/snapshots/spreadsheets_anywhere/snapshot_ssa_aws_ips.sql
+++ b/data/transform/snapshots/spreadsheets_anywhere/snapshot_ssa_aws_ips.sql
@@ -1,7 +1,6 @@
 {% snapshot snapshot_ssa_aws_ips %}
 
-    {{
-        config(
+{{ config(
           target_schema=generate_schema_name('snapshot'),
           strategy='check',
           unique_key='ip_address',

--- a/data/transform/snapshots/spreadsheets_anywhere/snapshot_ssa_azure_ips.sql
+++ b/data/transform/snapshots/spreadsheets_anywhere/snapshot_ssa_azure_ips.sql
@@ -1,7 +1,6 @@
 {% snapshot snapshot_ssa_azure_ips %}
 
-    {{
-        config(
+{{ config(
           target_schema=generate_schema_name('snapshot'),
           strategy='check',
           unique_key='ip_address',

--- a/data/transform/snapshots/spreadsheets_anywhere/snapshot_ssa_gcp_ips.sql
+++ b/data/transform/snapshots/spreadsheets_anywhere/snapshot_ssa_gcp_ips.sql
@@ -1,7 +1,6 @@
 {% snapshot snapshot_ssa_gcp_ips %}
 
-    {{
-        config(
+{{ config(
           target_schema=generate_schema_name('snapshot'),
           strategy='check',
           unique_key='id',

--- a/data/utilities/utilities.meltano.yml
+++ b/data/utilities/utilities.meltano.yml
@@ -2,7 +2,7 @@ plugins:
   utilities:
   - name: sqlfluff
     variant: sqlfluff
-    pip_url: sqlfluff==1.2.1; sqlfluff-templater-dbt==1.2.1; dbt-core~=1.2.0; dbt-snowflake~=1.2.0
+    pip_url: sqlfluff==1.4.5; sqlfluff-templater-dbt==1.4.5; dbt-core~=1.3.0; dbt-snowflake~=1.3.0
     settings:
     - name: user
       env: DBT_SNOWFLAKE_USER


### PR DESCRIPTION
- bumps sqlfluff version
- reduces the amount of snowplow data to use
- uses more fine grained default start dates for certain taps to limit data set size
- adds a script that outputs the sql files that have changed so sqlfluff only needs to run against those