### PR TITLE
add persisted_random for random ids that are long lived

### DIFF
--- a/data/transform/models/marts/telemetry/project_dim.sql
+++ b/data/transform/models/marts/telemetry/project_dim.sql
@@ -38,6 +38,9 @@ SELECT
     COALESCE(
         project_base.pipeline_runs_count_success, 0
     ) AS pipeline_runs_count_success,
+    COALESCE(
+        project_base.unique_ip_address_count, 0
+    ) AS unique_ip_address_count,
     COALESCE(project_base.add_count_all, 0) AS add_count_all,
     COALESCE(project_base.add_count_success, 0) AS add_count_success,
     COALESCE(project_base.config_count_all, 0) AS config_count_all,


### PR DESCRIPTION
Closes https://github.com/meltano/internal-data/issues/80

- adds `persisted_random` for when we think a random project ID source has graduated to an explicit persisted one. This is based on > 7 days old and > 1 IP address
- adds unique IP address count to project dim. It was needed for this and could be helpful to expose in general.
- I created a new project ID source type because it allows us to exclude them if we want to see our original metrics without this change.

Note this will change our primary metrics in the positive direction slightly. See https://github.com/meltano/internal-data/issues/80#issuecomment-1430394074 for details.

cc @tayloramurphy 