### PR TITLE
Hubspot publish data

### DIFF
--- a/data/orchestrate/orchestrators.meltano.yml
+++ b/data/orchestrate/orchestrators.meltano.yml
@@ -59,7 +59,16 @@ schedules:
   interval: 0 8 * * *
   job: marts_refresh
 
+- name: hubspot_publish
+  interval: 0 12 * * *
+  job: hubspot_publish
+
 jobs:
+
+- name: hubspot_publish
+  tasks:
+  - dbt-snowflake:run_hubspot_publish
+  - dbt-snowflake:test_hubspot_publish
 
 - name: slack_notifications
   tasks:

--- a/data/transform/dbt_project.yml
+++ b/data/transform/dbt_project.yml
@@ -68,6 +68,8 @@ models:
       slack_notifications:
         +materialized: view
         +schema: slack_notifications
+      hubspot:
+        +schema: hubspot
     # ------------------
     # Common
     # ------------------

--- a/data/transform/dbt_project.yml
+++ b/data/transform/dbt_project.yml
@@ -69,6 +69,7 @@ models:
         +materialized: view
         +schema: slack_notifications
       hubspot:
+        +materialized: view
         +schema: hubspot
     # ------------------
     # Common

--- a/data/transform/models/marts/telemetry/base/ip_address_dim.sql
+++ b/data/transform/models/marts/telemetry/base/ip_address_dim.sql
@@ -84,7 +84,8 @@ SELECT
     END AS execution_location,
     base.active_from,
     base.active_to,
-    ip_org_mapping_lm.leadmagic_company_name AS org_name
+    ip_org_mapping_lm.leadmagic_company_name AS org_name,
+    ip_org_mapping_lm.leadmagic_company_domain AS org_domain
 FROM base
 LEFT JOIN {{ ref('ip_org_mapping_lm') }}
     ON base.ip_address_hash = ip_org_mapping_lm.ip_address_hash
@@ -101,7 +102,8 @@ SELECT
     'REMOTE' AS execution_location,
     '2022-11-16' AS active_from,
     NULL AS active_to,
-    NULL AS org_name
+    NULL AS org_name,
+    NULL AS org_domain
 FROM {{ ref('meltano_cloud_ips') }}
 
 UNION ALL
@@ -113,4 +115,5 @@ SELECT
     'UNKNOWN' AS execution_location,
     NULL AS active_from,
     NULL AS active_to,
-    NULL AS org_name
+    NULL AS org_name,
+    NULL AS org_domain

--- a/data/transform/models/marts/telemetry/base/project_base.sql
+++ b/data/transform/models/marts/telemetry/base/project_base.sql
@@ -386,7 +386,11 @@ SELECT
     COALESCE(
         project_org_mapping.org_name,
         'UNKNOWN'
-    ) AS project_org_name
+    ) AS project_org_name,
+    COALESCE(
+        project_org_mapping.org_domain,
+        'UNKNOWN'
+    ) AS project_org_domain
 FROM project_aggregates
 LEFT JOIN
     first_values ON

--- a/data/transform/models/marts/telemetry/base/project_org_mapping.sql
+++ b/data/transform/models/marts/telemetry/base/project_org_mapping.sql
@@ -3,6 +3,7 @@ WITH base AS (
 
     SELECT
         ip_address_dim.org_name,
+        ip_address_dim.org_domain,
         cli_executions_base.project_id
     FROM {{ ref('cli_executions_base') }}
     LEFT JOIN {{ ref('ip_address_dim') }}
@@ -27,6 +28,7 @@ single_org_projects AS (
 
 SELECT DISTINCT
     base.org_name,
+    base.org_domain,
     base.project_id,
     'LEADMAGIC' AS org_source
 FROM base
@@ -37,6 +39,7 @@ UNION ALL
 
 SELECT DISTINCT
     org_name,
+    org_domain,
     project_id,
     'MANUAL' AS org_source
 FROM {{ ref('internal_data', 'project_org_manual') }}

--- a/data/transform/models/marts/telemetry/project_dim.sql
+++ b/data/transform/models/marts/telemetry/project_dim.sql
@@ -26,6 +26,7 @@ SELECT
     project_base.init_project_directory,
     project_base.has_opted_out,
     project_base.project_org_name,
+    project_base.project_org_domain,
     COALESCE(project_base.event_total, 0) AS event_total,
     COALESCE(project_base.exec_event_total, 0) AS exec_event_total,
     COALESCE(

--- a/data/transform/models/publish/hubspot/org_activity.sql
+++ b/data/transform/models/publish/hubspot/org_activity.sql
@@ -2,8 +2,7 @@ WITH base AS (
     SELECT *
     FROM {{ ref('project_dim') }}
     WHERE project_org_name != 'UNKNOWN'
-)
-,
+),
 
 activity AS (
     SELECT
@@ -19,7 +18,7 @@ activity AS (
                 END
             ),
             0
-        ) AS pipeline_runs_lm,
+        ) AS pipeline_runs_l30,
         ARRAY_TO_STRING(
             ARRAY_AGG(
                 DISTINCT fact_cli_executions.monthly_piplines_active_eom_segment
@@ -34,7 +33,7 @@ activity AS (
     FROM {{ ref('fact_cli_executions') }}
     INNER JOIN base
         ON fact_cli_executions.project_id = base.project_id
-    WHERE fact_cli_executions.date_day >= DATEADD('month', -1, CURRENT_DATE())
+    WHERE fact_cli_executions.date_day >= DATEADD('day', -30, CURRENT_DATE())
     GROUP BY 1, 2
 ),
 
@@ -52,7 +51,8 @@ plugins AS (
 
 SELECT
     activity.*,
-    plugins.unique_plugins
+    plugins.unique_plugins,
+    CURRENT_DATE() AS current_as_of_date
 FROM activity
 LEFT JOIN plugins
     ON plugins.project_org_domain = activity.project_org_domain

--- a/data/transform/models/publish/hubspot/org_activity.sql
+++ b/data/transform/models/publish/hubspot/org_activity.sql
@@ -1,7 +1,6 @@
 WITH base AS (
-    SELECT
-        *
-    FROM  {{ ref('project_dim') }}
+    SELECT *
+    FROM {{ ref('project_dim') }}
     WHERE project_org_name != 'UNKNOWN'
 )
 ,
@@ -11,14 +10,28 @@ activity AS (
         base.project_org_name,
         base.project_org_domain,
         COUNT(DISTINCT base.project_id) AS project_ids,
-        COALESCE(SUM(CASE WHEN fact_cli_executions.pipeline_fk IS NOT NULL THEN fact_cli_executions.event_count END), 0) AS pipeline_runs_lm,
-        ARRAY_TO_STRING(ARRAY_AGG(DISTINCT fact_cli_executions.monthly_piplines_active_eom_segment), ' || ') AS segments,
+        COALESCE(
+            SUM(
+                CASE
+                    WHEN
+                        fact_cli_executions.pipeline_fk IS NOT NULL
+                        THEN fact_cli_executions.event_count
+                END
+            ),
+            0
+        ) AS pipeline_runs_lm,
+        ARRAY_TO_STRING(
+            ARRAY_AGG(
+                DISTINCT fact_cli_executions.monthly_piplines_active_eom_segment
+            ),
+            ' || '
+        ) AS segments,
         MIN(base.project_first_event_at) AS org_first_event_at,
         MAX(base.project_last_event_at) AS org_last_event_at,
         MIN(base.project_first_active_date) AS org_first_active_date,
         MAX(base.project_last_active_date) AS org_last_active_date,
         MAX(fact_cli_executions.is_currently_active) AS is_currently_active
-    FROM  {{ ref('fact_cli_executions') }}
+    FROM {{ ref('fact_cli_executions') }}
     INNER JOIN base
         ON fact_cli_executions.project_id = base.project_id
     WHERE fact_cli_executions.date_day >= DATEADD('month', -1, CURRENT_DATE())
@@ -30,7 +43,7 @@ plugins AS (
         base.project_org_name,
         base.project_org_domain,
         COUNT(DISTINCT fact_plugin_usage.plugin_name) AS unique_plugins
-    FROM  {{ ref('fact_plugin_usage') }}
+    FROM {{ ref('fact_plugin_usage') }}
     INNER JOIN base
         ON fact_plugin_usage.project_id = base.project_id
     WHERE fact_plugin_usage.date_day >= DATEADD('month', -1, CURRENT_DATE())
@@ -43,4 +56,3 @@ SELECT
 FROM activity
 LEFT JOIN plugins
     ON plugins.project_org_domain = activity.project_org_domain
-

--- a/data/transform/models/publish/hubspot/org_activity.sql
+++ b/data/transform/models/publish/hubspot/org_activity.sql
@@ -1,0 +1,46 @@
+WITH base AS (
+    SELECT
+        *
+    FROM  {{ ref('project_dim') }}
+    WHERE project_org_name != 'UNKNOWN'
+)
+,
+
+activity AS (
+    SELECT
+        base.project_org_name,
+        base.project_org_domain,
+        COUNT(DISTINCT base.project_id) AS project_ids,
+        COALESCE(SUM(CASE WHEN fact_cli_executions.pipeline_fk IS NOT NULL THEN fact_cli_executions.event_count END), 0) AS pipeline_runs_lm,
+        ARRAY_TO_STRING(ARRAY_AGG(DISTINCT fact_cli_executions.monthly_piplines_active_eom_segment), ' || ') AS segments,
+        MIN(base.project_first_event_at) AS org_first_event_at,
+        MAX(base.project_last_event_at) AS org_last_event_at,
+        MIN(base.project_first_active_date) AS org_first_active_date,
+        MAX(base.project_last_active_date) AS org_last_active_date,
+        MAX(fact_cli_executions.is_currently_active) AS is_currently_active
+    FROM  {{ ref('fact_cli_executions') }}
+    INNER JOIN base
+        ON fact_cli_executions.project_id = base.project_id
+    WHERE fact_cli_executions.date_day >= DATEADD('month', -1, CURRENT_DATE())
+    GROUP BY 1, 2
+),
+
+plugins AS (
+    SELECT
+        base.project_org_name,
+        base.project_org_domain,
+        COUNT(DISTINCT fact_plugin_usage.plugin_name) AS unique_plugins
+    FROM  {{ ref('fact_plugin_usage') }}
+    INNER JOIN base
+        ON fact_plugin_usage.project_id = base.project_id
+    WHERE fact_plugin_usage.date_day >= DATEADD('month', -1, CURRENT_DATE())
+    GROUP BY 1, 2
+)
+
+SELECT
+    activity.*,
+    plugins.unique_plugins
+FROM activity
+LEFT JOIN plugins
+    ON plugins.project_org_domain = activity.project_org_domain
+

--- a/data/transform/models/publish/hubspot/schema.yml
+++ b/data/transform/models/publish/hubspot/schema.yml
@@ -8,7 +8,9 @@ models:
         description: The organization name.
         tests:
           - not_null
+          - unique
       - name: project_org_domain
         description: The organization domain url.
         tests:
           - not_null
+          - unique

--- a/data/transform/models/publish/hubspot/schema.yml
+++ b/data/transform/models/publish/hubspot/schema.yml
@@ -1,0 +1,14 @@
+version: 2
+
+models:
+  - name: org_activity
+    description: This table includes activity rolled up to the organization level.
+    columns:
+      - name: project_org_name
+        description: The organization name.
+        tests:
+          - not_null
+      - name: project_org_domain
+        description: The organization domain url.
+        tests:
+          - not_null

--- a/data/transform/transformers.meltano.yml
+++ b/data/transform/transformers.meltano.yml
@@ -36,6 +36,9 @@ plugins:
       run_hub_metrics: run --select publish.meltano_hub.*
       test_hub_metrics: test --select publish.meltano_hub.*
       run_slack_notifications: run --select +publish.slack_notifications.*
+      run_hubspot_publish: run --select publish.hubspot.*
+      test_hubspot_publish: test --select publish.hubspot.*
+
     config:
       account: epa06486
       database_raw: RAW


### PR DESCRIPTION
Closes https://github.com/meltano/internal-data/issues/82

@tayloramurphy @DouweM heres a sample of what the PR will provide, I improvised a bit. I'm happy to add/remove/edit anything to make it easier to upload. Once this merges I was thinking that I'd make a table chart in superset so anyone on our team can download the newest data as a CSV for upload, until we automate it.

PROJECT_ORG_NAME | PROJECT_ORG_DOMAIN | PROJECT_IDS | PIPELINE_RUNS_L30 | SEGMENTS | ORG_FIRST_EVENT_AT | ORG_LAST_EVENT_AT | ORG_FIRST_ACTIVE_DATE | ORG_LAST_ACTIVE_DATE | IS_CURRENTLY_ACTIVE | UNIQUE_PLUGINS | CURRENT_AS_OF
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
Meltano Squared | github.com/meltano/squared | 1 | 63 | MARLIN \|\| GUPPY | 2021-03-05 0:00:00 | 2023-02-14 6:06:30 | 2021-03-19 | 2023-02-15 | TRUE | 8 | 2023-02-22


Things to note:
- An organization can have many project ids so these metrics are aggregates i.e. pipelines counts across projects, unique plugins across projects. I thought this was useful to view them holistically.
- This looks back 30 days from today so segments for current month could be understated
- Since they can be many segments I concatenated them. `MARLIN || GUPPY` could mean an org has a single project that was a guppy last month and is now a marlin by increasing usage. Or it could mean it was a marlin last month and is still a guppy for the first part of this month, eventually to become a marlin by end of month. Or it could mean theres many projects owned by this org and some are guppy and some are marlins. With all these caveats, I'm fine to remove this if its too confusing but thought it would be nice to see if the org ever ventured into whale territory.
