### PR TITLE
add Sven as snowflake developer

### DIFF
--- a/data/utilities/permifrost/roles.yml
+++ b/data/utilities/permifrost/roles.yml
@@ -502,6 +502,10 @@ roles:
                     - staging_prod.*.*
                     - staging_raw.*.*
 
+    - sbalnojan:
+        member_of:
+            - developer
+
     - rbaum: 
         member_of: []
 
@@ -630,6 +634,11 @@ users:
         can_login: yes
         member_of:
             - ryan_miranda
+
+    - sbalnojan:
+        can_login: yes
+        member_of:
+            - sbalnojan
 
 # ==========================================
 # Warehouses


### PR DESCRIPTION
Closes https://github.com/meltano/internal-data/issues/90

@sbalnojan I decided that its probably easier for everyone if I give you access as a normal squared developer. I'll share the credentials with you directly but it limits you from doing anything unsafe, same as my account does. You can CRUD in USERDEV_<X> and CICD_<x> but read-only in raw/prep/prod. This way if you ever want to test or contribute anything in Squared you have the proper access.