### PR TITLE
chose a single options dict for the execution

### DIFF
--- a/data/.sqlfluff
+++ b/data/.sqlfluff
@@ -17,7 +17,9 @@ profile = meltano
 tab_space_size = 4
 max_line_length = 80
 indent_unit = space
-comma_style = trailing
+
+[sqlfluff:layout:type:comma]
+line_position = trailing
 
 [sqlfluff:rules:L010] # Keywords
 capitalisation_policy = upper

--- a/data/transform/models/marts/telemetry/base/unstructured_parsing/unstruct_exec_flattened.sql
+++ b/data/transform/models/marts/telemetry/base/unstructured_parsing/unstruct_exec_flattened.sql
@@ -30,7 +30,6 @@ plugins AS (
 SELECT
     base.context_uuid AS execution_id,
     plugins.plugin_list_of_lists AS plugins,
-    CASE WHEN base.opt_obj_row_num = 1 THEN base.options_obj END AS options_obj,
     MIN(base.event_created_at) AS started_ts,
     MAX(base.event_created_at) AS finished_ts,
     MAX(base.ip_address_hash) AS ip_address_hash,
@@ -48,6 +47,12 @@ SELECT
     MAX(base.machine) AS machine,
     MAX(base.system_release) AS system_release,
     MAX(base.project_uuid_source) AS project_uuid_source,
+    GET(
+        ARRAY_AGG(
+            CASE WHEN base.opt_obj_row_num = 1 THEN base.options_obj END
+        ),
+        0
+    ) AS options_obj,
     MAX(base.freedesktop_id) AS freedesktop_id,
     MAX(base.freedesktop_id_like) AS freedesktop_id_like,
     MAX(base.is_dev_build) AS is_dev_build,
@@ -90,4 +95,4 @@ FROM base
 LEFT JOIN plugins
     ON base.context_uuid = plugins.context_uuid
 WHERE base.event_name != 'telemetry_state_change_event'
-GROUP BY 1, 2, 3
+GROUP BY 1, 2

--- a/data/transform/models/marts/telemetry/base/unstructured_parsing/unstruct_exec_flattened.sql
+++ b/data/transform/models/marts/telemetry/base/unstructured_parsing/unstruct_exec_flattened.sql
@@ -2,79 +2,92 @@
     config(materialized='table')
 }}
 
-WITH plugins AS (
+WITH base AS (
 
     SELECT
-        unstruct_event_flattened.context_uuid,
+        *,
+        ROW_NUMBER() OVER (
+            PARTITION BY
+                context_uuid
+            ORDER BY LEN(options_obj::string) DESC
+        ) AS opt_obj_row_num
+    FROM {{ ref('unstruct_event_flattened') }}
+
+),
+
+plugins AS (
+
+    SELECT
+        base.context_uuid,
         ARRAY_AGG(DISTINCT plugin_list.value) AS plugin_list_of_lists
-    FROM {{ ref('unstruct_event_flattened') }},
+    FROM base,
         LATERAL FLATTEN(input => plugins_obj) AS plugin_list
-    WHERE unstruct_event_flattened.event_name != 'telemetry_state_change_event'
+    WHERE base.event_name != 'telemetry_state_change_event'
     GROUP BY 1
 
 )
 
 SELECT
-    unstruct_event_flattened.context_uuid AS execution_id,
+    base.context_uuid AS execution_id,
     plugins.plugin_list_of_lists AS plugins,
-    MIN(unstruct_event_flattened.event_created_at) AS started_ts,
-    MAX(unstruct_event_flattened.event_created_at) AS finished_ts,
-    MAX(unstruct_event_flattened.ip_address_hash) AS ip_address_hash,
-    MAX(unstruct_event_flattened.project_uuid) AS project_id,
+    CASE WHEN base.opt_obj_row_num = 1 THEN base.options_obj END AS options_obj,
+    MIN(base.event_created_at) AS started_ts,
+    MAX(base.event_created_at) AS finished_ts,
+    MAX(base.ip_address_hash) AS ip_address_hash,
+    MAX(base.project_uuid) AS project_id,
     MAX(
-        unstruct_event_flattened.freedesktop_version_id
+        base.freedesktop_version_id
     ) AS freedesktop_version_id,
-    MAX(unstruct_event_flattened.meltano_version) AS meltano_version,
+    MAX(base.meltano_version) AS meltano_version,
     MAX(
-        unstruct_event_flattened.num_cpu_cores_available
+        base.num_cpu_cores_available
     ) AS num_cpu_cores_available,
-    MAX(unstruct_event_flattened.windows_edition) AS windows_edition,
-    MAX(unstruct_event_flattened.command) AS cli_command,
-    MAX(unstruct_event_flattened.sub_command) AS cli_sub_command,
-    MAX(unstruct_event_flattened.machine) AS machine,
-    MAX(unstruct_event_flattened.system_release) AS system_release,
-    MAX(unstruct_event_flattened.project_uuid_source) AS project_uuid_source,
-    ARRAY_AGG(unstruct_event_flattened.options_obj) AS options_obj,
-    MAX(unstruct_event_flattened.freedesktop_id) AS freedesktop_id,
-    MAX(unstruct_event_flattened.freedesktop_id_like) AS freedesktop_id_like,
-    MAX(unstruct_event_flattened.is_dev_build) AS is_dev_build,
-    MAX(unstruct_event_flattened.process_hierarchy) AS process_hierarchy,
-    MAX(unstruct_event_flattened.python_version) AS python_version,
+    MAX(base.windows_edition) AS windows_edition,
+    MAX(base.command) AS cli_command,
+    MAX(base.sub_command) AS cli_sub_command,
+    MAX(base.machine) AS machine,
+    MAX(base.system_release) AS system_release,
+    MAX(base.project_uuid_source) AS project_uuid_source,
+    MAX(base.freedesktop_id) AS freedesktop_id,
+    MAX(base.freedesktop_id_like) AS freedesktop_id_like,
+    MAX(base.is_dev_build) AS is_dev_build,
+    MAX(base.process_hierarchy) AS process_hierarchy,
+    MAX(base.python_version) AS python_version,
     MAX(
-        unstruct_event_flattened.environment_name_hash
+        base.environment_name_hash
     ) AS environment_name_hash,
-    MAX(unstruct_event_flattened.client_uuid) AS client_uuid,
-    MAX(unstruct_event_flattened.is_ci_environment) AS is_ci_environment,
-    MAX(unstruct_event_flattened.num_cpu_cores) AS num_cpu_cores,
+    MAX(base.client_uuid) AS client_uuid,
+    MAX(base.is_ci_environment) AS is_ci_environment,
+    MAX(base.num_cpu_cores) AS num_cpu_cores,
     MAX(
-        unstruct_event_flattened.python_implementation
+        base.python_implementation
     ) AS python_implementation,
-    MAX(unstruct_event_flattened.system_name) AS system_name,
-    MAX(unstruct_event_flattened.system_version) AS system_version,
+    MAX(base.system_name) AS system_name,
+    MAX(base.system_version) AS system_version,
     -- Exit Event
-    MAX(unstruct_event_flattened.exit_code) AS exit_code,
-    MAX(unstruct_event_flattened.exit_timestamp) AS exit_ts,
+    MAX(base.exit_code) AS exit_code,
+    MAX(base.exit_timestamp) AS exit_ts,
     MAX(
-        unstruct_event_flattened.process_duration_microseconds
+        base.process_duration_microseconds
     ) * 1.0 / 1000 AS process_duration_ms,
     -- Exception
     MAX(
-        (unstruct_event_flattened.exception::VARIANT):type::STRING
+        (base.exception::VARIANT):type::STRING -- noqa: L063
     ) AS exception_type,
     MAX(
         NULLIF(
-            (unstruct_event_flattened.exception::VARIANT):cause::STRING, 'null'
+            (base.exception::VARIANT):cause::STRING, 'null' -- noqa: L063
         )
     ) AS exception_cause,
     -- Tracing
     -- TODO: event states are deduped here, maybe agg differently
-    ARRAY_AGG(unstruct_event_flattened.event) AS event_states,
+    ARRAY_AGG(base.event) AS event_states,
     ARRAY_AGG(
-        DISTINCT unstruct_event_flattened.block_type
+        DISTINCT base.block_type
     ) AS event_block_types,
-    ARRAY_AGG(DISTINCT unstruct_event_flattened.event_name) AS event_names
-FROM {{ ref('unstruct_event_flattened') }}
+    ARRAY_AGG(DISTINCT base.event_name) AS event_names
+FROM base
 LEFT JOIN plugins
-    ON unstruct_event_flattened.context_uuid = plugins.context_uuid
-WHERE unstruct_event_flattened.event_name != 'telemetry_state_change_event'
-GROUP BY 1, 2
+    ON base.context_uuid = plugins.context_uuid
+WHERE base.event_name != 'telemetry_state_change_event'
+GROUP BY 1, 2, 3


### PR DESCRIPTION
Previously we were using ARRAY_AGG for rolling up all the options dicts from individual events up to an execution. I realized that this was unnecessary because an execution really only has 1 set of options even though we're sent one with each event (cli start/inflight/complete/exit). By selecting one options dict for the execution it lets us parse the dict much easier later using key lookups vs iterating an array then doing key lookups in each item.

I ended up deciding to get the max length of each dict then chose the largest. I noticed that the last event usually has the most populated options dict with all previous dict data plus any additions but there were a handful of edge cases where legacy events got fired or the event ordering was off for whatever reason so the simplest solutions was to select the biggest dict for each execution. This means we're selecting the most populated set of options we know about.

@WillDaSilva do you see anything wrong with these assumptions and the logic as I've described it for parsing options dicts?