### PR TITLE
Feature tagging

### DIFF
--- a/data/transform/macros/feature_usage_macro.sql
+++ b/data/transform/macros/feature_usage_macro.sql
@@ -1,0 +1,14 @@
+{% macro feature_usage_macro(cte_list) -%}
+
+    {% for cte in cte_list %}
+        {%- if not loop.first %}
+        UNION ALL
+        {% endif -%}
+
+        SELECT
+            feature_id,
+            execution_id
+        FROM {{ cte }}
+    {% endfor %}
+
+{%- endmacro %}

--- a/data/transform/models/marts/telemetry/base/feature_usage_base.sql
+++ b/data/transform/models/marts/telemetry/base/feature_usage_base.sql
@@ -58,10 +58,9 @@ run AS (
         execution_id
     FROM {{ ref('fact_cli_executions') }}
     WHERE cli_command = 'run'
-),
+)
 
-all_features AS (
-    {{ feature_usage_macro(
+{{ feature_usage_macro(
     [
         'interactive_config',
         'elt_state',
@@ -72,12 +71,3 @@ all_features AS (
         'run'
     ]
 ) }}
-
-)
-
-SELECT
-    fact_cli_executions.*,
-    all_features.feature_id
-FROM all_features
-LEFT JOIN {{ ref('fact_cli_executions') }}
-    ON all_features.execution_id = fact_cli_executions.execution_id

--- a/data/transform/models/marts/telemetry/fact_feature_usage.sql
+++ b/data/transform/models/marts/telemetry/fact_feature_usage.sql
@@ -1,7 +1,7 @@
 WITH interactive_config AS (
     SELECT
         'INTERACTIVE_CONFIG' AS feature_id,
-        cli_executions_base.execution_id
+        execution_id
     FROM {{ ref('cli_executions_base') }}
     WHERE cli_command = 'config'
         AND GET(COALESCE(GET(options_obj, 'set'), {}), 'interactive') = TRUE
@@ -10,7 +10,7 @@ WITH interactive_config AS (
 elt_state AS (
     SELECT
         'ELT_STATE_ARG' AS feature_id,
-        cli_executions_base.execution_id
+        execution_id
     FROM {{ ref('cli_executions_base') }}
     WHERE cli_command = 'elt'
         AND NULLIF(

--- a/data/transform/models/marts/telemetry/fact_feature_usage.sql
+++ b/data/transform/models/marts/telemetry/fact_feature_usage.sql
@@ -1,0 +1,83 @@
+WITH interactive_config AS (
+    SELECT
+        'INTERACTIVE_CONFIG' AS feature_id,
+        cli_executions_base.execution_id
+    FROM {{ ref('cli_executions_base') }}
+    WHERE cli_command = 'config'
+        AND GET(COALESCE(GET(options_obj, 'set'), {}), 'interactive') = TRUE
+),
+
+elt_state AS (
+    SELECT
+        'ELT_STATE_ARG' AS feature_id,
+        cli_executions_base.execution_id
+    FROM {{ ref('cli_executions_base') }}
+    WHERE cli_command = 'elt'
+        AND NULLIF(
+            TRIM(GET(COALESCE(GET(options_obj, 'elt'), {}), 'state')), 'null'
+        ) IS NOT NULL
+
+),
+
+plugin_inherits_from AS (
+    SELECT DISTINCT
+        'PLUGIN_INHERITS_FROM' AS feature_id,
+        execution_id
+    FROM {{ ref('fact_plugin_usage') }}
+    WHERE parent_name != 'UNKNOWN'
+        AND parent_name != plugin_name
+),
+
+mappers AS (
+    SELECT DISTINCT
+        'MAPPERS' AS feature_id,
+        execution_id
+    FROM {{ ref('fact_plugin_usage') }}
+    WHERE plugin_type = 'mappers'
+),
+
+environments AS (
+    SELECT
+        'ENVIRONMENTS' AS feature_id,
+        execution_id
+    FROM {{ ref('cli_executions_base') }}
+    WHERE environment_name_hash IS NOT NULL
+),
+
+test AS (
+    SELECT
+        'TEST' AS feature_id,
+        execution_id
+    FROM {{ ref('fact_cli_executions') }}
+    WHERE cli_command = 'test'
+),
+
+run AS (
+    SELECT
+        'RUN' AS feature_id,
+        execution_id
+    FROM {{ ref('fact_cli_executions') }}
+    WHERE cli_command = 'run'
+),
+
+all_features AS (
+    {{ feature_usage_macro(
+    [
+        'interactive_config',
+        'elt_state',
+        'plugin_inherits_from',
+        'mappers',
+        'environments',
+        'test',
+        'run'
+    ]
+) }}
+
+)
+
+SELECT
+    fact_cli_executions.*,
+    all_features.feature_id
+FROM all_features
+LEFT JOIN {{ ref('fact_cli_executions') }}
+    ON all_features.execution_id = fact_cli_executions.execution_id


### PR DESCRIPTION
Closes https://github.com/meltano/squared/issues/530

This is probably just the first iteration for this table. It adds a pattern for tagging executions as using a feature using CTEs and a macro to union all of them together. I'm imagining that once we have a better sense of what we want out of this we can either join/aggregate in different ways to use this:
- **Features as entities:** left join fact_cli_executions to get a feature grain table with all execution attributes.
  - This makes it easier to group by all available feature. The feature is the entity like a `fact_feature_execution`.
  - Once features are tagged they flow through automatically
  - Use cases: generic feature usage over time.
- **Features as attributes:** aggregate all these features up to the single execution
  - once aggregated we can add a `is_[FEATURE_X]` attribute for each feature to the executions table. This helps for filtering for specific features but its harder to generically dimension by all available features.
  - if a new feature is added the BI layer will need to updated to incorporate them this way because the table structure changed so they need to be pulled in and used where needed.
  - Use cases: filter projects that use a particular feature. 


Its possible that both of these are valuable and can be added in the future as needed. For now we have the foundation for easily tagging them.