### PR TITLE
Filter more ephemeral new projects

### DIFF
--- a/data/transform/macros/project_funnel.sql
+++ b/data/transform/macros/project_funnel.sql
@@ -13,6 +13,7 @@ WITH active_executions AS (
 
     SELECT
         project_id,
+        array_agg(distinct ip_address_hash) as ips,
         SUM(
             CASE WHEN is_active_cli_execution THEN 1 END
         ) AS active_executions_count
@@ -20,15 +21,38 @@ WITH active_executions AS (
     GROUP BY 1
 ),
 
+first_exec AS (
+
+    SELECT
+        project_id,
+	    GET(
+            FIRST_VALUE(
+                options_obj
+            ) OVER (
+                PARTITION BY
+                    project_id
+                ORDER BY COALESCE(started_ts, finished_ts) ASC
+            ),
+            0
+        ):elt:state::STRING AS first_elt_uses_state
+    FROM {{ ref('cli_executions_base') }}
+    WHERE CLI_COMMAND = 'elt'
+
+),
+
 project_base AS (
 
     SELECT
         project_dim.*,
+        first_exec.first_elt_uses_state,
+        case when array_size(ips) = 1 then ips[0] end as ip_address_hash,
         active_executions.active_executions_count,
         DATE_TRUNC(WEEK, project_dim.project_first_event_at) AS cohort_week
     FROM {{ ref('project_dim') }}
     LEFT JOIN active_executions
         ON project_dim.project_id = active_executions.project_id
+    LEFT JOIN first_exec
+        ON project_dim.project_id = first_exec.project_id
     {% if project_where_filter %}{{ project_where_filter }}{% endif %}
     
 

--- a/data/transform/models/marts/telemetry/base/project_base.sql
+++ b/data/transform/models/marts/telemetry/base/project_base.sql
@@ -3,6 +3,13 @@ WITH first_values AS (
     SELECT DISTINCT
         project_id,
         FIRST_VALUE(
+            CASE WHEN is_exec_event = TRUE THEN options_obj END
+        ) IGNORE NULLS OVER (
+            PARTITION BY
+                project_id
+            ORDER BY COALESCE(started_ts, finished_ts) ASC
+        ):elt:state::STRING AS first_elt_state,
+        FIRST_VALUE(
             CASE
                 WHEN cli_command != 'init'
                     THEN project_uuid_source
@@ -30,14 +37,7 @@ WITH first_values AS (
             PARTITION BY
                 project_id
             ORDER BY COALESCE(started_ts, finished_ts) ASC
-        ) AS first_project_directory,
-        FIRST_VALUE(
-            CASE WHEN is_exec_event = TRUE THEN options_obj END
-        ) IGNORE NULLS OVER (
-            PARTITION BY
-                project_id
-            ORDER BY COALESCE(started_ts, finished_ts) ASC
-        ):elt:state::STRING AS first_elt_state
+        ) AS first_project_directory
     FROM {{ ref('cli_executions_base') }}
 
 ),
@@ -234,7 +234,7 @@ plugin_aggregates AS (
 project_aggregates AS (
     SELECT
         cli_executions_base.project_id,
-        ARRAY_AGG(DISTINCT ip_address_hash) as ip_hash_list,
+        ARRAY_AGG(DISTINCT cli_executions_base.ip_address_hash) AS ip_hash_list,
         MIN(cli_executions_base.event_created_at) AS first_event_at,
         MAX(cli_executions_base.event_created_at) AS last_event_at,
         DATEDIFF(
@@ -399,7 +399,9 @@ SELECT
         project_org_mapping.org_domain,
         'UNKNOWN'
     ) AS project_org_domain,
-    CASE WHEN first_values.first_elt_state IS NOT NULL THEN TRUE ELSE FALSE END AS is_state_in_first_exec
+    COALESCE(first_values.first_elt_state IS NOT NULL,
+        FALSE
+    ) AS is_state_in_first_exec
 FROM project_aggregates
 LEFT JOIN
     first_values ON

--- a/data/transform/models/marts/telemetry/project_dim.sql
+++ b/data/transform/models/marts/telemetry/project_dim.sql
@@ -134,9 +134,14 @@ SELECT
         project_base.project_id_source = 'random'
         OR project_base.is_ci_only = TRUE
         OR project_base.lifespan_mins <= 5
-        -- CI ONLY
-        -- state in first command
-        ,
+        OR project_base.is_state_in_first_exec = TRUE
+        OR (
+            ARRAY_SIZE(project_base.ip_hash_list) = 1
+            -- Ephemeral IP exclude list
+            AND project_base.ip_hash_list[0] IN (
+                'e6e4b47d8cd8840dd90ea08f5e54033f'
+            )
+        ),
         FALSE
     ) AS is_ephemeral_project_id,
     COALESCE(

--- a/data/transform/models/marts/telemetry/project_dim.sql
+++ b/data/transform/models/marts/telemetry/project_dim.sql
@@ -133,7 +133,10 @@ SELECT
     COALESCE(
         project_base.project_id_source = 'random'
         OR project_base.is_ci_only = TRUE
-        OR project_base.lifespan_mins <= 5,
+        OR project_base.lifespan_mins <= 5
+        -- CI ONLY
+        -- state in first command
+        ,
         FALSE
     ) AS is_ephemeral_project_id,
     COALESCE(

--- a/data/transform/models/marts/telemetry/project_funnel_cohort.sql
+++ b/data/transform/models/marts/telemetry/project_funnel_cohort.sql
@@ -18,12 +18,12 @@
         'parent_name': 'NOT_OPT_OUT',
         'filter': "project_lifespan_mins > 5"
 	},
-    "NOT_STATE_FIRST_ELT": {
+    "NOT_EPHEMERAL_OTHER": {
         'parent_name': 'MINS_5_OR_LONGER',
-        'filter': "(first_elt_uses_state IS NULL AND coalesce(ip_address_hash, '') != 'e6e4b47d8cd8840dd90ea08f5e54033f')"
+        'filter': "is_ephemeral_project_id = FALSE"
 	},
     "ADD_OR_INSTALL_ATTEMPT": {
-        'parent_name': 'NOT_STATE_FIRST_ELT',
+        'parent_name': 'NOT_EPHEMERAL_OTHER',
         'filter': "(add_count_all > 0 OR install_count_all > 0)"
 	},
     "ADD_OR_INSTALL_SUCCESS": {

--- a/data/transform/models/marts/telemetry/project_funnel_cohort.sql
+++ b/data/transform/models/marts/telemetry/project_funnel_cohort.sql
@@ -89,4 +89,4 @@
 	}
 %}
 
-{{ project_funnel(mapping, alt_base_level='MINS_5_OR_LONGER') }}
+{{ project_funnel(mapping, alt_base_level='NOT_EPHEMERAL_OTHER') }}

--- a/data/transform/models/marts/telemetry/project_funnel_cohort.sql
+++ b/data/transform/models/marts/telemetry/project_funnel_cohort.sql
@@ -18,8 +18,12 @@
         'parent_name': 'NOT_OPT_OUT',
         'filter': "project_lifespan_mins > 5"
 	},
-    "ADD_OR_INSTALL_ATTEMPT": {
+    "NOT_STATE_FIRST_ELT": {
         'parent_name': 'MINS_5_OR_LONGER',
+        'filter': "(first_elt_uses_state IS NULL AND coalesce(ip_address_hash, '') != 'e6e4b47d8cd8840dd90ea08f5e54033f')"
+	},
+    "ADD_OR_INSTALL_ATTEMPT": {
+        'parent_name': 'NOT_STATE_FIRST_ELT',
         'filter': "(add_count_all > 0 OR install_count_all > 0)"
 	},
     "ADD_OR_INSTALL_SUCCESS": {

--- a/data/transform/models/marts/telemetry/project_funnel_cohort_codespaces.sql
+++ b/data/transform/models/marts/telemetry/project_funnel_cohort_codespaces.sql
@@ -18,8 +18,12 @@
         'parent_name': 'NOT_OPT_OUT',
         'filter': "project_lifespan_mins > 5"
 	},
-    "ADD_OR_INSTALL_ATTEMPT": {
+    "NOT_EPHEMERAL_OTHER": {
         'parent_name': 'MINS_5_OR_LONGER',
+        'filter': "is_ephemeral_project_id = FALSE"
+	},
+    "ADD_OR_INSTALL_ATTEMPT": {
+        'parent_name': 'NOT_EPHEMERAL_OTHER',
         'filter': "(add_count_all > 0 OR install_count_all > 0)"
 	},
     "ADD_OR_INSTALL_SUCCESS": {
@@ -88,5 +92,5 @@
 {{ project_funnel(
     mapping,
     project_where_filter='WHERE project_dim.is_codespace_demo = TRUE',
-    alt_base_level='MINS_5_OR_LONGER'
+    alt_base_level='NOT_EPHEMERAL_OTHER'
 ) }}


### PR DESCRIPTION
Closes https://github.com/meltano/internal-data/issues/81

- Adds new filters to is_ephemeral_project_id attribute for excluding certain problem IP hashes and when a projects first execution command included the `--state` flag meaning the project was previously run elsewhere.
- These flow through to all charts and metrics that use the is_ephemeral_project_id attribute for filtering
- In the cohort tables I kept the existing funnel levels but added an addition one that uses the is_ephemeral_project_id attribute to catch any projects not caught by the previous filters. In this case it filter for the `--state` projects and excluded ip hashes. I did this so that we can consistently define what ephemeral is and use it in other places outside the cohort funnels and also keep the current funnel levels in place.
- These changes required that we bump the base funnel level up one place so the % of base charts use the new filters.

After this merges I will need to update the % base charts to bump the base funnel level otherwise the first funnel will always be 100%.

cc @tayloramurphy 