### PR TITLE
fix: option object parsing

### DIFF
--- a/data/extract/extractors.meltano.yml
+++ b/data/extract/extractors.meltano.yml
@@ -39,7 +39,7 @@ plugins:
         start_date: '2020-01-01T00:00:00Z'
         key_properties: [id]
         name: azure_ips
-        pattern: ServiceTags_Public_20230227.json
+        pattern: ServiceTags_Public_20230313.json
         json_path: values
   - name: tap-slack
     variant: meltanolabs

--- a/data/transform/models/marts/telemetry/base/unstructured_parsing/unstruct_exec_flattened.sql
+++ b/data/transform/models/marts/telemetry/base/unstructured_parsing/unstruct_exec_flattened.sql
@@ -9,7 +9,7 @@ WITH base AS (
         ROW_NUMBER() OVER (
             PARTITION BY
                 context_uuid
-            ORDER BY LEN(options_obj::string) DESC
+            ORDER BY COALESCE(LEN(options_obj::string), 0) DESC
         ) AS opt_obj_row_num
     FROM {{ ref('unstruct_event_flattened') }}
 


### PR DESCRIPTION
Closes https://github.com/meltano/internal-data/issues/91

This fixes a bug that was causing null options to flow through in some cases. Downstream we're using those options to flag codespaces projects so some/most projects werent getting flagged.