### PR TITLE
Upgrade sqlfluff

### DIFF
--- a/data/.sqlfluff
+++ b/data/.sqlfluff
@@ -2,30 +2,20 @@
 [sqlfluff]
 dialect = snowflake
 templater = dbt
-output_line_length = 80
-ignore_templated_areas = True
 runaway_limit = 100
 # Bug https://github.com/sqlfluff/sqlfluff/issues/4188
-exclude_rules = L071
+# exclude_rules = L071
 
 [sqlfluff:templater:dbt]
 project_dir = transform
 profiles_dir = transform/profiles/snowflake/
 profile = meltano
 
-[sqlfluff:rules]
-tab_space_size = 4
-max_line_length = 80
-indent_unit = space
-
-[sqlfluff:layout:type:comma]
-line_position = trailing
-
-[sqlfluff:rules:L010] # Keywords
+[sqlfluff:rules:capitalisation.keywords]
 capitalisation_policy = upper
 
-[sqlfluff:rules:L014] # Unquoted Identifiers
+[sqlfluff:rules:capitalisation.identifiers]
 extended_capitalisation_policy = lower
 
-[sqlfluff:rules:L030] # Function Names
+[sqlfluff:rules:capitalisation.functions]
 capitalisation_policy = upper

--- a/data/environments/userdev.meltano.yml
+++ b/data/environments/userdev.meltano.yml
@@ -77,6 +77,7 @@ environments:
       - name: sqlfluff
         config:
           user: ${USER_PREFIX}
+          role: ${USER_PREFIX}
       - name: great_expectations
         config:
           prod_database: USERDEV_PROD

--- a/data/transform/models/common/date_dim.sql
+++ b/data/transform/models/common/date_dim.sql
@@ -34,14 +34,19 @@ calculated AS (
             DAYOFWEEK, date_day
         ) + 1 AS day_of_week,
 
-        CASE WHEN day_name = 'Sun' THEN date_day
-            ELSE DATEADD(
-                'day', -1, DATE_TRUNC('week', date_day)
-            ) END AS first_day_of_week,
+        CASE
+            WHEN day_name = 'Sun' THEN date_day
+            ELSE
+                DATEADD(
+                    'day', -1, DATE_TRUNC('week', date_day)
+                )
+        END AS first_day_of_week,
 
-        CASE WHEN day_name = 'Sun' THEN WEEK(date_day) + 1
+        CASE
+            WHEN day_name = 'Sun' THEN WEEK(date_day) + 1
             --remove this column
-            ELSE WEEK(date_day) END AS week_of_year_temp,
+            ELSE WEEK(date_day)
+        END AS week_of_year_temp,
 
         CASE
             WHEN
@@ -49,7 +54,8 @@ calculated AS (
                     week_of_year_temp
                 ) OVER (ORDER BY date_day) = '1'
                 THEN '1'
-            ELSE week_of_year_temp END AS week_of_year,
+            ELSE week_of_year_temp
+        END AS week_of_year,
 
         DATE_PART(
             'day', date_day
@@ -63,15 +69,19 @@ calculated AS (
             PARTITION BY year_actual ORDER BY date_day
         ) AS day_of_year,
 
-        CASE WHEN month_actual < 2
-            THEN year_actual
-            ELSE (year_actual + 1) END AS fiscal_year,
+        CASE
+            WHEN month_actual < 2
+                THEN year_actual
+            ELSE (year_actual + 1)
+        END AS fiscal_year,
 
-        CASE WHEN month_actual < 2 THEN '4'
+        CASE
+            WHEN month_actual < 2 THEN '4'
             WHEN month_actual < 5 THEN '1'
             WHEN month_actual < 8 THEN '2'
             WHEN month_actual < 11 THEN '3'
-            ELSE '4' END AS fiscal_quarter,
+            ELSE '4'
+        END AS fiscal_quarter,
 
         ROW_NUMBER() OVER (
             PARTITION BY fiscal_year, fiscal_quarter ORDER BY date_day
@@ -145,8 +155,10 @@ calculated AS (
             'week', first_day_of_fiscal_year, date_day
         ) + 1 AS week_of_fiscal_year,
 
-        CASE WHEN EXTRACT('month', date_day) = 1 THEN 12
-            ELSE EXTRACT('month', date_day) - 1 END AS month_of_fiscal_year,
+        CASE
+            WHEN EXTRACT('month', date_day) = 1 THEN 12
+            ELSE EXTRACT('month', date_day) - 1
+        END AS month_of_fiscal_year,
 
         LAST_VALUE(
             date_day
@@ -158,7 +170,8 @@ calculated AS (
             year_actual || '-Q' || EXTRACT(QUARTER FROM date_day)
         ) AS quarter_name,
 
-        (fiscal_year || '-' || DECODE(fiscal_quarter,
+        (fiscal_year || '-' || DECODE(
+            fiscal_quarter,
             1, 'Q1',
             2, 'Q2',
             3, 'Q3',

--- a/data/transform/models/marts/community/base/username_mapping.sql
+++ b/data/transform/models/marts/community/base/username_mapping.sql
@@ -61,10 +61,10 @@ blend_all AS (
     FROM name_matches
     LEFT JOIN
         {{ ref('contributor_id_mapping') }} AS hub ON
-            name_matches.github_author_id = hub.github_id
+        name_matches.github_author_id = hub.github_id
     LEFT JOIN
         {{ ref('contributor_id_mapping') }} AS lab ON
-            name_matches.gitlab_author_id = lab.gitlab_id
+        name_matches.gitlab_author_id = lab.gitlab_id
 )
 
 SELECT

--- a/data/transform/models/marts/community/contributions.sql
+++ b/data/transform/models/marts/community/contributions.sql
@@ -1,4 +1,3 @@
-
 {{ config(materialized='view') }}
 
 WITH gitlab_all AS (
@@ -17,8 +16,10 @@ WITH gitlab_all AS (
         state,
         is_work_in_progress AS is_draft,
         comment_count,
-        COALESCE((merged_at_ts IS NOT NULL OR closed_at_ts IS NOT NULL),
-            FALSE) AS is_completed
+        COALESCE(
+            (merged_at_ts IS NOT NULL OR closed_at_ts IS NOT NULL),
+            FALSE
+        ) AS is_completed
     FROM {{ ref('stg_gitlab__merge_requests') }}
 
     UNION ALL
@@ -61,8 +62,10 @@ github_all AS (
         state,
         is_draft,
         comment_count,
-        COALESCE((merged_at_ts IS NOT NULL OR closed_at_ts IS NOT NULL),
-            FALSE) AS is_completed
+        COALESCE(
+            (merged_at_ts IS NOT NULL OR closed_at_ts IS NOT NULL),
+            FALSE
+        ) AS is_completed
     FROM {{ ref('stg_github__pull_requests') }}
 
     UNION ALL
@@ -110,10 +113,12 @@ gitlab_combined AS (
         CASE
             WHEN
                 gitlab_all.contribution_type = 'issue'
-                THEN 'https://gitlab.com/'
-                || stg_gitlab__projects.repo_full_name
-                || '/-/issues/' || gitlab_all.contribution_number::STRING
-            ELSE 'https://gitlab.com/' || stg_gitlab__projects.repo_full_name
+                THEN
+                    'https://gitlab.com/'
+                    || stg_gitlab__projects.repo_full_name
+                    || '/-/issues/' || gitlab_all.contribution_number::STRING
+            ELSE
+                'https://gitlab.com/' || stg_gitlab__projects.repo_full_name
                 || '/-/merge_requests/'
                 || gitlab_all.contribution_number::STRING
         END AS contribution_url,
@@ -127,13 +132,13 @@ gitlab_combined AS (
     FROM gitlab_all
     LEFT JOIN
         {{ ref('team_gitlab_ids') }} ON
-            gitlab_all.author_id = team_gitlab_ids.user_id
+        gitlab_all.author_id = team_gitlab_ids.user_id
     LEFT JOIN
         {{ ref('stg_gitlab__projects') }} ON
-            gitlab_all.project_id = stg_gitlab__projects.project_id
+        gitlab_all.project_id = stg_gitlab__projects.project_id
     LEFT JOIN
         {{ ref('username_mapping') }} ON
-            gitlab_all.author_id = username_mapping.gitlab_author_id
+        gitlab_all.author_id = username_mapping.gitlab_author_id
     WHERE stg_gitlab__projects.visibility = 'public'
 ),
 
@@ -158,9 +163,11 @@ github_combined AS (
         CASE
             WHEN
                 github_all.contribution_type = 'issue'
-                THEN stg_github__repositories.html_url || '/issues/'
-                || github_all.contribution_number::STRING
-            ELSE stg_github__repositories.html_url || '/pull/'
+                THEN
+                    stg_github__repositories.html_url || '/issues/'
+                    || github_all.contribution_number::STRING
+            ELSE
+                stg_github__repositories.html_url || '/pull/'
                 || github_all.contribution_number::STRING
         END AS contribution_url,
         (
@@ -173,14 +180,16 @@ github_combined AS (
     FROM github_all
     LEFT JOIN
         {{ ref('team_github_ids') }} ON
-            github_all.author_id = team_github_ids.user_id
-    LEFT JOIN {{ ref('stg_github__repositories') }} ON
+        github_all.author_id = team_github_ids.user_id
+    LEFT JOIN
+        {{ ref('stg_github__repositories') }} ON
         github_all.organization_name = stg_github__repositories.organization_name -- noqa: L016
         AND github_all.repo_name = stg_github__repositories.repo_name
     LEFT JOIN
         {{ ref('username_mapping') }} ON
-            github_all.author_id = username_mapping.github_author_id
-    WHERE stg_github__repositories.visibility = 'public'
+        github_all.author_id = username_mapping.github_author_id
+    WHERE
+        stg_github__repositories.visibility = 'public'
         AND github_all.is_bot_user = FALSE
 )
 

--- a/data/transform/models/marts/community/singer_contributions.sql
+++ b/data/transform/models/marts/community/singer_contributions.sql
@@ -52,7 +52,7 @@ LEFT JOIN {{ ref('stg_meltanohub__plugins') }}
         ) = LOWER(stg_github_search__repositories.repo_url)
 LEFT JOIN
     {{ ref('team_github_ids') }} ON
-        stg_github_search__issues.author_id = team_github_ids.user_id
+    stg_github_search__issues.author_id = team_github_ids.user_id
 
 UNION ALL
 
@@ -110,4 +110,4 @@ LEFT JOIN {{ ref('stg_meltanohub__plugins') }}
         ) = LOWER(stg_github_search__repositories.repo_url)
 LEFT JOIN
     {{ ref('team_github_ids') }} ON
-        stg_github_search__pull_requests.author_id = team_github_ids.user_id
+    stg_github_search__pull_requests.author_id = team_github_ids.user_id

--- a/data/transform/models/marts/community/slack_company_domains.sql
+++ b/data/transform/models/marts/community/slack_company_domains.sql
@@ -5,7 +5,8 @@ WITH company_domains AS (
             message_created_at, CAST('1900-01-01' AS DATE)
         ) AS first_joined_date
     FROM {{ ref('slack_new_members') }}
-    WHERE email_domain
+    WHERE
+        email_domain
         NOT IN (
             'gmail.com',
             'meltano.com',

--- a/data/transform/models/marts/community/slack_members_daily.sql
+++ b/data/transform/models/marts/community/slack_members_daily.sql
@@ -7,7 +7,8 @@ WITH new_member_message AS (
         ) AS parsed_user_id
     FROM {{ ref('stg_slack__messages') }}
     -- new-member-notice channel
-    WHERE channel_id = 'C01SK13R9NJ'
+    WHERE
+        channel_id = 'C01SK13R9NJ'
         AND slack_username = 'New User Alert [bot]'
 
 ),
@@ -27,8 +28,9 @@ base AS (
     FROM {{ ref('stg_slack__users') }}
     LEFT JOIN
         new_member_message ON
-            stg_slack__users.user_id = new_member_message.parsed_user_id
-    WHERE NOT stg_slack__users.is_bot
+        stg_slack__users.user_id = new_member_message.parsed_user_id
+    WHERE
+        NOT stg_slack__users.is_bot
         AND stg_slack__users.user_id != 'USLACKBOT'
         AND stg_slack__users.is_deleted = FALSE
 ),

--- a/data/transform/models/marts/community/slack_new_members.sql
+++ b/data/transform/models/marts/community/slack_new_members.sql
@@ -7,7 +7,8 @@ WITH new_member_message AS (
         ) AS parsed_user_id
     FROM {{ ref('stg_slack__messages') }}
     -- new-member-notice channel
-    WHERE channel_id = 'C01SK13R9NJ'
+    WHERE
+        channel_id = 'C01SK13R9NJ'
         AND slack_username = 'New User Alert [bot]'
 
 )
@@ -21,6 +22,7 @@ SELECT
 FROM {{ ref('stg_slack__users') }}
 LEFT JOIN
     new_member_message ON
-        stg_slack__users.user_id = new_member_message.parsed_user_id
-WHERE NOT stg_slack__users.is_bot
+    stg_slack__users.user_id = new_member_message.parsed_user_id
+WHERE
+    NOT stg_slack__users.is_bot
     AND stg_slack__users.user_id != 'USLACKBOT'

--- a/data/transform/models/marts/telemetry/active_projects_28d.sql
+++ b/data/transform/models/marts/telemetry/active_projects_28d.sql
@@ -41,7 +41,8 @@ SELECT
                 SELECT
                     fact_cli_executions.date_day,
                     fact_cli_executions.project_id,
-                    COUNT(DISTINCT
+                    COUNT(
+                        DISTINCT
                         fact_cli_executions.pipeline_fk
                     ) AS pipeline_count
                 FROM {{ ref('fact_cli_executions') }}
@@ -54,6 +55,7 @@ SELECT
             AND pipe_exec.pipeline_count > 1
     ) AS unique_pipe_greater_1_monthly
 FROM {{ ref('date_dim') }}
-WHERE date_day
+WHERE
+    date_day
     BETWEEN DATEADD(YEAR, -2, CURRENT_TIMESTAMP())
     AND CURRENT_TIMESTAMP()

--- a/data/transform/models/marts/telemetry/base/cli_execs_blended.sql
+++ b/data/transform/models/marts/telemetry/base/cli_execs_blended.sql
@@ -12,7 +12,7 @@ SELECT
 FROM {{ ref('unstruct_exec_flattened') }}
 INNER JOIN
     {{ ref('event_src_activation') }} ON
-        unstruct_exec_flattened.project_id = event_src_activation.project_id
+    unstruct_exec_flattened.project_id = event_src_activation.project_id
 WHERE
     unstruct_exec_flattened.started_ts >= event_src_activation.sp_activate_date
 
@@ -28,7 +28,7 @@ SELECT
 FROM {{ ref('stg_snowplow__events') }}
 INNER JOIN
     {{ ref('event_src_activation') }} ON
-        stg_snowplow__events.se_label = event_src_activation.project_id
+    stg_snowplow__events.se_label = event_src_activation.project_id
 WHERE
     stg_snowplow__events.event_created_date
     >= event_src_activation.sp_activate_date
@@ -49,8 +49,9 @@ SELECT
 FROM {{ ref('stg_ga__cli_events') }}
 LEFT JOIN
     {{ ref('event_src_activation') }} ON
-        stg_ga__cli_events.project_id = event_src_activation.project_id
+    stg_ga__cli_events.project_id = event_src_activation.project_id
 WHERE
-    (event_src_activation.sp_activate_date IS NULL
+    (
+        event_src_activation.sp_activate_date IS NULL
         OR stg_ga__cli_events.event_date < event_src_activation.sp_activate_date
     )

--- a/data/transform/models/marts/telemetry/base/cli_executions_base.sql
+++ b/data/transform/models/marts/telemetry/base/cli_executions_base.sql
@@ -107,7 +107,8 @@ combined AS (
         event_commands_parsed.is_os_feature_mappers,
         event_commands_parsed.is_os_feature_test,
         event_commands_parsed.is_os_feature_run,
-        COALESCE(NOT(event_commands_parsed.is_plugin_dbt
+        COALESCE(NOT(
+            event_commands_parsed.is_plugin_dbt
             OR event_commands_parsed.is_plugin_singer
             OR event_commands_parsed.is_plugin_airflow
             OR event_commands_parsed.is_plugin_dagster
@@ -118,10 +119,12 @@ combined AS (
         ), FALSE) AS is_plugin_other,
         COALESCE(
             retention.first_event_date = structured_executions.event_created_at,
-            FALSE) AS is_acquired_date,
+            FALSE
+        ) AS is_acquired_date,
         COALESCE(
             retention.last_event_date = structured_executions.event_created_at,
-            FALSE) AS is_churned_date,
+            FALSE
+        ) AS is_churned_date,
         COALESCE(
             structured_executions.event_created_at >= DATEADD(
                 MONTH, 1, DATE_TRUNC(
@@ -137,7 +140,7 @@ combined AS (
         ON structured_executions.command = event_commands_parsed.command
     LEFT JOIN
         {{ ref('cmd_parsed_all') }} ON
-            structured_executions.command = cmd_parsed_all.command
+        structured_executions.command = cmd_parsed_all.command
     LEFT JOIN retention
         ON structured_executions.project_id = retention.project_id
 
@@ -173,13 +176,13 @@ combined AS (
         unstructured_executions.is_ci_environment,
         unstructured_executions.options_obj,
         COALESCE(unstructured_executions.cli_command IN (
-                'meltano transforms',
-                'meltano dashboards',
-                'meltano models',
-                'transforms',
-                'dashboards',
-                'models'
-            ), FALSE) AS is_legacy_event,
+            'meltano transforms',
+            'meltano dashboards',
+            'meltano models',
+            'transforms',
+            'dashboards',
+            'models'
+        ), FALSE) AS is_legacy_event,
 
         -- Plugins
         COALESCE(unstruct_prep.is_plugin_dbt, FALSE) AS is_plugin_dbt,
@@ -281,5 +284,6 @@ SELECT
     ) AS cli_runtime_ms
 FROM combined
 LEFT JOIN {{ ref('hash_lookup') }}
-    ON combined.environment_name_hash = hash_lookup.hash_value
+    ON
+        combined.environment_name_hash = hash_lookup.hash_value
         AND hash_lookup.category = 'environment'

--- a/data/transform/models/marts/telemetry/base/environments.sql
+++ b/data/transform/models/marts/telemetry/base/environments.sql
@@ -8,7 +8,8 @@ SELECT
 FROM {{ ref('structured_executions') }}
 LEFT JOIN
     {{ ref('cmd_parsed_all') }} ON
-        structured_executions.command = cmd_parsed_all.command
+    structured_executions.command = cmd_parsed_all.command
 LEFT JOIN {{ ref('hash_lookup') }}
-    ON cmd_parsed_all.environment = hash_lookup.hash_value
+    ON
+        cmd_parsed_all.environment = hash_lookup.hash_value
         AND hash_lookup.category = 'environment'

--- a/data/transform/models/marts/telemetry/base/event_commands_parsed.sql
+++ b/data/transform/models/marts/telemetry/base/event_commands_parsed.sql
@@ -103,7 +103,8 @@ singer AS (
 
     SELECT command
     FROM unique_commands
-    WHERE command_category = 'meltano invoke'
+    WHERE
+        command_category = 'meltano invoke'
         AND (
             split_part_3 LIKE 'tap%'
             OR split_part_3 LIKE 'pipelinewise-tap-%'
@@ -130,7 +131,8 @@ singer AS (
 dbt AS (
     SELECT command
     FROM unique_commands
-    WHERE command_category = 'meltano elt'
+    WHERE
+        command_category = 'meltano elt'
         AND command LIKE 'meltano elt% --transform run%'
 
     UNION ALL
@@ -143,14 +145,16 @@ dbt AS (
 
     SELECT command
     FROM unique_commands
-    WHERE command_category = 'meltano add transformers'
+    WHERE
+        command_category = 'meltano add transformers'
         AND split_part_4 LIKE 'dbt'
 
     UNION ALL
 
     SELECT command
     FROM unique_commands
-    WHERE command_category = 'meltano add files'
+    WHERE
+        command_category = 'meltano add files'
         AND split_part_4 LIKE 'dbt'
 
     UNION ALL
@@ -164,7 +168,8 @@ dbt AS (
 airflow AS (
     SELECT command
     FROM unique_commands
-    WHERE command_category = 'meltano invoke'
+    WHERE
+        command_category = 'meltano invoke'
         AND split_part_3 LIKE 'airflow%'
 
     UNION ALL
@@ -177,14 +182,16 @@ airflow AS (
 
     SELECT command
     FROM unique_commands
-    WHERE command_category = 'meltano add orchestrators'
+    WHERE
+        command_category = 'meltano add orchestrators'
         AND split_part_4 LIKE 'airflow'
 
     UNION ALL
 
     SELECT command
     FROM unique_commands
-    WHERE command_category = 'meltano add files'
+    WHERE
+        command_category = 'meltano add files'
         AND split_part_4 LIKE 'airflow'
 
     UNION ALL
@@ -199,14 +206,16 @@ dagster AS (
 
     SELECT command
     FROM unique_commands
-    WHERE command_category = 'meltano invoke'
+    WHERE
+        command_category = 'meltano invoke'
         AND split_part_3 LIKE 'dagster%'
 
     UNION ALL
 
     SELECT command
     FROM unique_commands
-    WHERE command_category = 'meltano add utilities'
+    WHERE
+        command_category = 'meltano add utilities'
         AND split_part_4 LIKE 'dagster%'
 
     UNION ALL
@@ -221,21 +230,24 @@ lightdash AS (
 
     SELECT command
     FROM unique_commands
-    WHERE command_category = 'meltano invoke'
+    WHERE
+        command_category = 'meltano invoke'
         AND split_part_3 LIKE 'lightdash%'
 
     UNION ALL
 
     SELECT command
     FROM unique_commands
-    WHERE command_category = 'meltano add utilities'
+    WHERE
+        command_category = 'meltano add utilities'
         AND split_part_4 LIKE 'lightdash'
 
     UNION ALL
 
     SELECT command
     FROM unique_commands
-    WHERE command_category = 'meltano add files'
+    WHERE
+        command_category = 'meltano add files'
         AND split_part_4 LIKE 'lightdash'
 
     UNION ALL
@@ -250,14 +262,16 @@ superset AS (
 
     SELECT command
     FROM unique_commands
-    WHERE command_category = 'meltano invoke'
+    WHERE
+        command_category = 'meltano invoke'
         AND split_part_3 LIKE 'superset%'
 
     UNION ALL
 
     SELECT command
     FROM unique_commands
-    WHERE command_category = 'meltano add files'
+    WHERE
+        command_category = 'meltano add files'
         AND split_part_4 LIKE 'superset'
 
     UNION ALL
@@ -272,21 +286,24 @@ sqlfluff AS (
 
     SELECT command
     FROM unique_commands
-    WHERE command_category = 'meltano invoke'
+    WHERE
+        command_category = 'meltano invoke'
         AND split_part_3 LIKE 'sqlfluff%'
 
     UNION ALL
 
     SELECT command
     FROM unique_commands
-    WHERE command_category = 'meltano add files'
+    WHERE
+        command_category = 'meltano add files'
         AND split_part_4 LIKE 'sqlfluff'
 
     UNION ALL
 
     SELECT command
     FROM unique_commands
-    WHERE command_category = 'meltano add utilities'
+    WHERE
+        command_category = 'meltano add utilities'
         AND split_part_4 LIKE 'sqlfluff'
 
     UNION ALL
@@ -301,22 +318,27 @@ great_expectations AS (
 
     SELECT command
     FROM unique_commands
-    WHERE command_category = 'meltano invoke'
-        AND (split_part_3 LIKE 'great-expectations%'
-            OR split_part_3 LIKE 'great_expectations%')
+    WHERE
+        command_category = 'meltano invoke'
+        AND (
+            split_part_3 LIKE 'great-expectations%'
+            OR split_part_3 LIKE 'great_expectations%'
+        )
 
     UNION ALL
 
     SELECT command
     FROM unique_commands
-    WHERE command_category = 'meltano add files'
+    WHERE
+        command_category = 'meltano add files'
         AND split_part_4 IN ('great-expectations', 'great_expectations')
 
     UNION ALL
 
     SELECT command
     FROM unique_commands
-    WHERE command_category = 'meltano add utilities'
+    WHERE
+        command_category = 'meltano add utilities'
         AND split_part_4 IN ('great-expectations', 'great_expectations')
 
     UNION ALL
@@ -357,7 +379,8 @@ cli_mappers AS (
     SELECT command
     FROM _run_parse
     -- Commands need at least 3 plugins to be considered.
-    WHERE NOT(
+    WHERE
+        NOT(
             SPLIT_PART(
                 command, ' ', 5
             ) = '' OR STARTSWITH(SPLIT_PART(command, ' ', 5), '--environment')

--- a/data/transform/models/marts/telemetry/base/event_src_activation.sql
+++ b/data/transform/models/marts/telemetry/base/event_src_activation.sql
@@ -17,7 +17,8 @@ snow_pre_v2 AS (
         COUNT(DISTINCT event_id) AS events
     FROM
         {{ ref('stg_snowplow__events') }}
-    WHERE contexts IS NULL
+    WHERE
+        contexts IS NULL
         AND event = 'struct'
         AND se_label IS NOT NULL
     GROUP BY 1, 2
@@ -38,7 +39,8 @@ prep_snow AS (
     FROM
         snow_v2
     FULL JOIN snow_pre_v2
-        ON snow_v2.project_id = snow_pre_v2.project_id
+        ON
+            snow_v2.project_id = snow_pre_v2.project_id
             AND snow_v2.event_week_start_date
             = snow_pre_v2.event_week_start_date
 
@@ -58,7 +60,9 @@ SELECT
     prep_snow.project_id,
     MIN(prep_snow.event_week_start_date) AS sp_activate_date
 FROM prep_snow
-LEFT JOIN prep_ga ON prep_snow.project_id = prep_ga.project_id
+LEFT JOIN
+    prep_ga ON
+    prep_snow.project_id = prep_ga.project_id
     AND prep_snow.event_week_start_date = prep_ga.event_week_start_date
 WHERE COALESCE(100 * (prep_snow.events * 1.0 / prep_ga.events), 100) >= 100
 GROUP BY 1

--- a/data/transform/models/marts/telemetry/base/feature_usage_base.sql
+++ b/data/transform/models/marts/telemetry/base/feature_usage_base.sql
@@ -3,8 +3,9 @@ WITH interactive_config AS (
         'INTERACTIVE_CONFIG' AS feature_id,
         execution_id
     FROM {{ ref('cli_executions_base') }}
-    WHERE cli_command = 'config'
-        AND GET(COALESCE(GET(options_obj, 'set'), {}), 'interactive') = TRUE
+    WHERE
+        cli_command = 'config'
+        AND GET(COALESCE(GET(options_obj, 'set'), { }), 'interactive') = TRUE
 ),
 
 elt_state AS (
@@ -12,9 +13,10 @@ elt_state AS (
         'ELT_STATE_ARG' AS feature_id,
         execution_id
     FROM {{ ref('cli_executions_base') }}
-    WHERE cli_command = 'elt'
+    WHERE
+        cli_command = 'elt'
         AND NULLIF(
-            TRIM(GET(COALESCE(GET(options_obj, 'elt'), {}), 'state')), 'null'
+            TRIM(GET(COALESCE(GET(options_obj, 'elt'), { }), 'state')), 'null'
         ) IS NOT NULL
 
 ),
@@ -24,7 +26,8 @@ plugin_inherits_from AS (
         'PLUGIN_INHERITS_FROM' AS feature_id,
         execution_id
     FROM {{ ref('fact_plugin_usage') }}
-    WHERE parent_name != 'UNKNOWN'
+    WHERE
+        parent_name != 'UNKNOWN'
         AND parent_name != plugin_name
 ),
 

--- a/data/transform/models/marts/telemetry/base/hash_lookup.sql
+++ b/data/transform/models/marts/telemetry/base/hash_lookup.sql
@@ -62,7 +62,7 @@ WITH base AS (
         SHA2_HEX(command.value::STRING) AS hash_value,
         'plugin_command' AS category
     FROM {{ ref('snapshot_meltanohub_plugins') }},
-        LATERAL FLATTEN(input=>OBJECT_KEYS(commands)) AS command
+        LATERAL FLATTEN(input => OBJECT_KEYS(commands)) AS command
     WHERE snapshot_meltanohub_plugins.commands IS NOT NULL
 
     UNION ALL

--- a/data/transform/models/marts/telemetry/base/hub_logs_parsed.sql
+++ b/data/transform/models/marts/telemetry/base/hub_logs_parsed.sql
@@ -21,7 +21,8 @@ WITH base AS (
             WHEN
                 startswith(
                     payload, 'Method'
-                ) THEN array_to_string(
+                ) THEN
+                array_to_string(
                     array_slice(split(payload, ':'), 1, 100000000), ':'
                 )
         END AS method_body,
@@ -31,13 +32,15 @@ WITH base AS (
         END AS status_code,
         CASE
             WHEN
-                payload LIKE 'Received response.%' THEN split_part(
+                payload LIKE 'Received response.%' THEN
+                split_part(
                     split_part(payload, 'Integration latency: ', 2), ' ms', 1
                 )
         END AS integration_latency_ms,
         CASE
             WHEN
-                user_agent LIKE 'Meltano%' THEN replace(
+                user_agent LIKE 'Meltano%' THEN
+                replace(
                     user_agent, 'Meltano/', ''
                 )
         END AS meltano_version,

--- a/data/transform/models/marts/telemetry/base/ip_address_dim.sql
+++ b/data/transform/models/marts/telemetry/base/ip_address_dim.sql
@@ -32,7 +32,8 @@ cloud_ips AS (
         LISTAGG(DISTINCT cloud_ip_ranges.service, ', ') AS cloud_services,
         LISTAGG(DISTINCT cloud_ip_ranges.region, ', ') AS cloud_regions
     FROM parsed, {{ ref('cloud_ip_ranges') }}
-    WHERE parsed.obj:ipv4 BETWEEN cloud_ip_ranges.ipv4_range_start
+    WHERE
+        parsed.obj:ipv4 BETWEEN cloud_ip_ranges.ipv4_range_start
         AND cloud_ip_ranges.ipv4_range_end
     GROUP BY 1, 2, 3
 

--- a/data/transform/models/marts/telemetry/base/opt_outs.sql
+++ b/data/transform/models/marts/telemetry/base/opt_outs.sql
@@ -6,7 +6,8 @@ SELECT
     project_uuid AS project_id,
     MIN(event_created_at) AS opted_out_at
 FROM {{ ref('unstruct_event_flattened') }}
-WHERE event_name = 'telemetry_state_change_event'
+WHERE
+    event_name = 'telemetry_state_change_event'
     AND setting_name = 'send_anonymous_usage_stats'
     AND changed_to = 'false'
 GROUP BY 1

--- a/data/transform/models/marts/telemetry/base/pipeline_executions.sql
+++ b/data/transform/models/marts/telemetry/base/pipeline_executions.sql
@@ -9,10 +9,11 @@ WITH plugin_prep AS (
                 plugin_executions.plugin_name
             )
         ) WITHIN GROUP (
-            ORDER BY plugin_executions.plugin_started, COALESCE(
-                plugin_executions.plugin_surrogate_key,
-                plugin_executions.plugin_name
-            ) DESC
+            ORDER BY
+                plugin_executions.plugin_started, COALESCE(
+                    plugin_executions.plugin_surrogate_key,
+                    plugin_executions.plugin_name
+                ) DESC
         ) AS plugins
     FROM {{ ref('plugin_executions') }}
     LEFT JOIN {{ ref('cli_executions_base') }}

--- a/data/transform/models/marts/telemetry/base/plugin_executions.sql
+++ b/data/transform/models/marts/telemetry/base/plugin_executions.sql
@@ -77,26 +77,29 @@ SELECT
     base.plugin_surrogate_key,
     base.completion_status AS completion_sub_status,
     CASE
-        WHEN base.completion_status IN (
-            'SUCCESS',
-            'SUCCESS_STRUCT',
-            'SUCCESS_BLOCK_CLI_LEVEL'
-        ) THEN 'SUCCESS'
+        WHEN
+            base.completion_status IN (
+                'SUCCESS',
+                'SUCCESS_STRUCT',
+                'SUCCESS_BLOCK_CLI_LEVEL'
+            ) THEN 'SUCCESS'
         WHEN base.completion_status IN ('FAILED') THEN 'FAILED'
-        WHEN base.completion_status IN (
-            'ABORTED-SKIPPED',
-            'INCOMPLETE_EL_PAIR'
-        ) THEN 'ABORTED'
-        WHEN base.completion_status IN (
-            'NULL_EXCEPTION',
-            'EXCEPTION_PARSING_FAILED',
-            'OTHER_FAILURE',
-            'FAILED_BLOCK_CLI_LEVEL'
-        ) THEN 'UNKNOWN_FAILED_OR_ABORTED'
+        WHEN
+            base.completion_status IN (
+                'ABORTED-SKIPPED',
+                'INCOMPLETE_EL_PAIR'
+            ) THEN 'ABORTED'
+        WHEN
+            base.completion_status IN (
+                'NULL_EXCEPTION',
+                'EXCEPTION_PARSING_FAILED',
+                'OTHER_FAILURE',
+                'FAILED_BLOCK_CLI_LEVEL'
+            ) THEN 'UNKNOWN_FAILED_OR_ABORTED'
         ELSE 'OTHER'
     END AS completion_status
 FROM base
 -- Exclude non-activated projects based on GA vs Snowplow
 INNER JOIN
     {{ ref('cli_execs_blended') }} ON
-        base.execution_id = cli_execs_blended.execution_id
+    base.execution_id = cli_execs_blended.execution_id

--- a/data/transform/models/marts/telemetry/base/project_base.sql
+++ b/data/transform/models/marts/telemetry/base/project_base.sql
@@ -131,7 +131,8 @@ plugin_aggregates AS (
         ) AS el_plugin_pip_url_count_success,
         COUNT(
             DISTINCT CASE
-                WHEN cli_executions_base.cli_command IN ('add', 'install')
+                WHEN
+                    cli_executions_base.cli_command IN ('add', 'install')
                     AND plugin_executions.plugin_name NOT IN (
                         'tap-gitlab',
                         'tap-github',
@@ -146,7 +147,8 @@ plugin_aggregates AS (
         ) AS non_gsg_add,
         COUNT(
             DISTINCT CASE
-                WHEN cli_executions_base.cli_command IN ('add', 'install')
+                WHEN
+                    cli_executions_base.cli_command IN ('add', 'install')
                     AND plugin_executions.plugin_name NOT IN (
                         'tap-gitlab',
                         'tap-github',
@@ -162,7 +164,8 @@ plugin_aggregates AS (
         ) AS non_gsg_add_success,
         COUNT(
             DISTINCT CASE
-                WHEN cli_executions_base.is_exec_event
+                WHEN
+                    cli_executions_base.is_exec_event
                     AND plugin_executions.plugin_name NOT IN (
                         'tap-gitlab',
                         'tap-github',
@@ -177,7 +180,8 @@ plugin_aggregates AS (
         ) AS non_gsg_exec,
         COUNT(
             DISTINCT CASE
-                WHEN cli_executions_base.is_exec_event
+                WHEN
+                    cli_executions_base.is_exec_event
                     AND plugin_executions.plugin_name NOT IN (
                         'tap-gitlab',
                         'tap-github',
@@ -193,7 +197,8 @@ plugin_aggregates AS (
         ) AS non_gsg_exec_success,
         COUNT(
             DISTINCT CASE
-                WHEN pipeline_executions.pipeline_pk IS NOT NULL
+                WHEN
+                    pipeline_executions.pipeline_pk IS NOT NULL
                     AND plugin_executions.plugin_name NOT IN (
                         'tap-gitlab',
                         'tap-github',
@@ -208,7 +213,8 @@ plugin_aggregates AS (
         ) AS non_gsg_pipeline,
         COUNT(
             DISTINCT CASE
-                WHEN pipeline_executions.pipeline_pk IS NOT NULL
+                WHEN
+                    pipeline_executions.pipeline_pk IS NOT NULL
                     AND plugin_executions.plugin_name NOT IN (
                         'tap-gitlab',
                         'tap-github',
@@ -316,24 +322,24 @@ project_aggregates AS (
             'upgrade',
             'version',
         ] %}
-        SUM(
-            CASE
-                WHEN
-                    cli_executions_base.cli_command = '{{ cli_command }}'
-                    THEN cli_executions_base.event_count
-            END
-        ) AS {{ cli_command }}_count_all,
-        SUM(
-            CASE
-                WHEN
-                    cli_executions_base.cli_command = '{{ cli_command }}'
-                    AND COALESCE(
-                        cli_executions_base.exit_code, 1
-                    ) = 0 THEN cli_executions_base.event_count
-            END
-        ) AS {{ cli_command }}_count_success
+            SUM(
+                CASE
+                    WHEN
+                        cli_executions_base.cli_command = '{{ cli_command }}'
+                        THEN cli_executions_base.event_count
+                END
+            ) AS {{ cli_command }}_count_all,
+            SUM(
+                CASE
+                    WHEN
+                        cli_executions_base.cli_command = '{{ cli_command }}'
+                        AND COALESCE(
+                            cli_executions_base.exit_code, 1
+                        ) = 0 THEN cli_executions_base.event_count
+                END
+            ) AS {{ cli_command }}_count_success
             {%- if not loop.last %},{% endif -%}
-		{% endfor %}
+        {% endfor %}
     -- Active execution events
     -- Current segment
     FROM {{ ref('cli_executions_base') }}
@@ -368,15 +374,17 @@ SELECT
     -- Handle random projects that look to have persisted their ID
     -- https://github.com/meltano/internal-data/issues/80
     CASE
-        WHEN first_values.first_source = 'random'
+        WHEN
+            first_values.first_source = 'random'
             AND project_aggregates.unique_ip_address_count > 1
             AND project_aggregates.lifespan_days > 7
             THEN 'persisted_random'
-        ELSE COALESCE(
-            first_values.first_source,
-            -- Pre 2.0 so no project_uuid_source present or only command is init
-            'UNKNOWN'
-        )
+        ELSE
+            COALESCE(
+                first_values.first_source,
+                -- Pre 2.0 so no project_uuid_source present or only command is init
+                'UNKNOWN'
+            )
     END AS project_id_source,
     COALESCE(
         first_values.first_meltano_version,
@@ -399,13 +407,14 @@ SELECT
         project_org_mapping.org_domain,
         'UNKNOWN'
     ) AS project_org_domain,
-    COALESCE(first_values.first_elt_state IS NOT NULL,
+    COALESCE(
+        first_values.first_elt_state IS NOT NULL,
         FALSE
     ) AS is_state_in_first_exec
 FROM project_aggregates
 LEFT JOIN
     first_values ON
-        project_aggregates.project_id = first_values.project_id
+    project_aggregates.project_id = first_values.project_id
 LEFT JOIN {{ ref('opt_outs') }}
     ON project_aggregates.project_id = opt_outs.project_id
 LEFT JOIN plugin_aggregates

--- a/data/transform/models/marts/telemetry/base/project_base.sql
+++ b/data/transform/models/marts/telemetry/base/project_base.sql
@@ -382,7 +382,8 @@ SELECT
         ELSE
             COALESCE(
                 first_values.first_source,
-                -- Pre 2.0 so no project_uuid_source present or only command is init
+                -- Pre 2.0 so no project_uuid_source present
+                -- or only command is init
                 'UNKNOWN'
             )
     END AS project_id_source,

--- a/data/transform/models/marts/telemetry/base/project_org_mapping.sql
+++ b/data/transform/models/marts/telemetry/base/project_org_mapping.sql
@@ -10,7 +10,8 @@ WITH base AS (
         ON cli_executions_base.ip_address_hash = ip_address_dim.ip_address_hash
     LEFT JOIN {{ ref('internal_data', 'project_org_manual') }}
         ON cli_executions_base.project_id = project_org_manual.project_id
-    WHERE ip_address_dim.org_name IS NOT NULL
+    WHERE
+        ip_address_dim.org_name IS NOT NULL
         -- Exclude manual override of Leadmagic
         AND project_org_manual.project_id IS NULL
 

--- a/data/transform/models/marts/telemetry/base/structured_parsing/args_parsed.sql
+++ b/data/transform/models/marts/telemetry/base/structured_parsing/args_parsed.sql
@@ -13,5 +13,5 @@ SELECT
     ) AS args
 FROM
     {{ ref('unique_commands') }},
-    LATERAL FLATTEN(input=>unique_commands.split_parts) AS flat
+    LATERAL FLATTEN(input => unique_commands.split_parts) AS flat
 GROUP BY 1, 2

--- a/data/transform/models/marts/telemetry/base/structured_parsing/cmd_parsed_add_remove.sql
+++ b/data/transform/models/marts/telemetry/base/structured_parsing/cmd_parsed_add_remove.sql
@@ -48,14 +48,16 @@ WITH prep AS (
                         ) = 'transform-field'
                     )
                 )
-                THEN [
-                    GET(unique_commands.split_parts, 3)::STRING
-                ] END AS singer_plugins,
+                THEN
+                    [
+                        GET(unique_commands.split_parts, 3)::STRING
+                    ]
+        END AS singer_plugins,
         GET(unique_commands.split_parts, 3) AS plugin
     FROM {{ ref('unique_commands') }}
     LEFT JOIN
         {{ ref('args_parsed') }} ON
-            unique_commands.command = args_parsed.command
+        unique_commands.command = args_parsed.command
     WHERE
         unique_commands.command_category LIKE 'meltano add %'
         OR unique_commands.command LIKE 'meltano remove %'

--- a/data/transform/models/marts/telemetry/base/structured_parsing/cmd_parsed_elt.sql
+++ b/data/transform/models/marts/telemetry/base/structured_parsing/cmd_parsed_elt.sql
@@ -9,7 +9,8 @@ SELECT
     COALESCE(
         unique_commands.command LIKE '%--transform run%'
         OR unique_commands.command LIKE '%--transform only%',
-        FALSE) AS dbt_run
+        FALSE
+    ) AS dbt_run
 FROM {{ ref('unique_commands') }}
 LEFT JOIN
     {{ ref('args_parsed') }} ON unique_commands.command = args_parsed.command

--- a/data/transform/models/marts/telemetry/base/structured_parsing/cmd_parsed_invoke.sql
+++ b/data/transform/models/marts/telemetry/base/structured_parsing/cmd_parsed_invoke.sql
@@ -5,7 +5,8 @@ WITH prep AS (
         args_parsed.args,
         args_parsed.environment,
         CASE
-            WHEN GET(unique_commands.split_parts, 2) NOT LIKE '--%'
+            WHEN
+                GET(unique_commands.split_parts, 2) NOT LIKE '--%'
                 AND (
                     GET(unique_commands.split_parts, 2) LIKE 'tap-%'
                     OR GET(unique_commands.split_parts, 2) LIKE 'tap_%'
@@ -28,7 +29,7 @@ WITH prep AS (
     FROM {{ ref('unique_commands') }}
     LEFT JOIN
         {{ ref('args_parsed') }} ON
-            unique_commands.command = args_parsed.command
+        unique_commands.command = args_parsed.command
     WHERE unique_commands.command_category = 'meltano invoke'
 )
 

--- a/data/transform/models/marts/telemetry/base/structured_parsing/cmd_parsed_run.sql
+++ b/data/transform/models/marts/telemetry/base/structured_parsing/cmd_parsed_run.sql
@@ -38,7 +38,8 @@ target_pairs AS (
         plugin_index,
         CASE
             WHEN
-                tap_index IS NOT NULL THEN LAG(
+                tap_index IS NOT NULL THEN
+                LAG(
                     target_index
                 ) IGNORE NULLS OVER (
                     PARTITION BY command ORDER BY plugin_index DESC
@@ -55,10 +56,10 @@ _mappers AS (
     FROM target_pairs
     INNER JOIN
         target_pairs AS t2 ON
-            target_pairs.command
-            = t2.command AND target_pairs.plugin_index
-            > t2.plugin_index AND target_pairs.plugin_index
-            < t2.target_pair_index
+        target_pairs.command
+        = t2.command AND target_pairs.plugin_index
+        > t2.plugin_index AND target_pairs.plugin_index
+        < t2.target_pair_index
 ),
 
 meltano_run AS (
@@ -66,31 +67,39 @@ meltano_run AS (
         _cmd_prep.command,
         _cmd_prep.command_category,
         ARRAY_AGG(
-            CASE WHEN
-                _cmd_prep.tap_index IS NOT NULL
-                OR _cmd_prep.target_index IS NOT NULL
-                OR _mappers.plugin_index IS NOT NULL
-                THEN _cmd_prep.plugin_element END
+            CASE
+                WHEN
+                    _cmd_prep.tap_index IS NOT NULL
+                    OR _cmd_prep.target_index IS NOT NULL
+                    OR _mappers.plugin_index IS NOT NULL
+                    THEN _cmd_prep.plugin_element
+            END
         ) WITHIN GROUP (ORDER BY _cmd_prep.plugin_index ASC) AS singer_plugins,
         ARRAY_AGG(
-            CASE WHEN _mappers.plugin_index IS NOT NULL
-                THEN _cmd_prep.plugin_element END
+            CASE
+                WHEN _mappers.plugin_index IS NOT NULL
+                    THEN _cmd_prep.plugin_element
+            END
         ) WITHIN GROUP (
             ORDER BY _cmd_prep.plugin_index ASC
         ) AS singer_mapper_plugins,
         ARRAY_AGG(
-            CASE WHEN _cmd_prep.tap_index IS NULL
-                AND _cmd_prep.target_index IS NULL
-                AND _mappers.plugin_index IS NULL
-                AND _cmd_prep.plugin_element NOT LIKE '--environment%'
-                THEN _cmd_prep.plugin_element END
+            CASE
+                WHEN
+                    _cmd_prep.tap_index IS NULL
+                    AND _cmd_prep.target_index IS NULL
+                    AND _mappers.plugin_index IS NULL
+                    AND _cmd_prep.plugin_element NOT LIKE '--environment%'
+                    THEN _cmd_prep.plugin_element
+            END
         ) WITHIN GROUP (ORDER BY _cmd_prep.plugin_index ASC) AS other_plugins
     FROM _cmd_prep
     LEFT JOIN
         _mappers ON
-            _cmd_prep.command = _mappers.command
-            AND _cmd_prep.plugin_index = _mappers.plugin_index
-    WHERE _cmd_prep.command_category = 'meltano run'
+        _cmd_prep.command = _mappers.command
+        AND _cmd_prep.plugin_index = _mappers.plugin_index
+    WHERE
+        _cmd_prep.command_category = 'meltano run'
         AND _cmd_prep.plugin_element NOT IN ('meltano', 'run')
     GROUP BY _cmd_prep.command, _cmd_prep.command_category
 )

--- a/data/transform/models/marts/telemetry/base/structured_parsing/cmd_parsed_schedule.sql
+++ b/data/transform/models/marts/telemetry/base/structured_parsing/cmd_parsed_schedule.sql
@@ -22,8 +22,9 @@ SELECT
 FROM {{ ref('unique_commands') }}
 LEFT JOIN
     {{ ref('args_parsed') }} ON
-        unique_commands.command = args_parsed.command
-WHERE unique_commands.command_category = 'meltano schedule'
+    unique_commands.command = args_parsed.command
+WHERE
+    unique_commands.command_category = 'meltano schedule'
     -- its a plugin name
     AND GET(unique_commands.split_parts, 2) NOT IN ('run', 'list', 'add')
 
@@ -55,8 +56,9 @@ SELECT
 FROM {{ ref('unique_commands') }}
 LEFT JOIN
     {{ ref('args_parsed') }} ON
-        unique_commands.command = args_parsed.command
-WHERE unique_commands.command_category = 'meltano schedule'
+    unique_commands.command = args_parsed.command
+WHERE
+    unique_commands.command_category = 'meltano schedule'
     -- its a plugin name just offset
     AND GET(unique_commands.split_parts, 2) IN ('add', 'run')
 
@@ -76,7 +78,8 @@ SELECT
 FROM {{ ref('unique_commands') }}
 LEFT JOIN
     {{ ref('args_parsed') }} ON
-        unique_commands.command = args_parsed.command
-WHERE unique_commands.command_category = 'meltano schedule'
+    unique_commands.command = args_parsed.command
+WHERE
+    unique_commands.command_category = 'meltano schedule'
     -- null plugins
     AND GET(unique_commands.split_parts, 2) = 'list'

--- a/data/transform/models/marts/telemetry/base/structured_parsing/cmd_parsed_test.sql
+++ b/data/transform/models/marts/telemetry/base/structured_parsing/cmd_parsed_test.sql
@@ -5,7 +5,8 @@ WITH prep AS (
         args_parsed.args,
         args_parsed.environment,
         CASE
-            WHEN GET(unique_commands.split_parts, 2) NOT LIKE '--%'
+            WHEN
+                GET(unique_commands.split_parts, 2) NOT LIKE '--%'
                 AND (
                     GET(unique_commands.split_parts, 2) LIKE 'tap-%'
                     OR GET(unique_commands.split_parts, 2) LIKE 'tap_%'
@@ -33,7 +34,7 @@ WITH prep AS (
     FROM {{ ref('unique_commands') }}
     LEFT JOIN
         {{ ref('args_parsed') }} ON
-            unique_commands.command = args_parsed.command
+        unique_commands.command = args_parsed.command
     WHERE unique_commands.command_category = 'meltano test'
 )
 

--- a/data/transform/models/marts/telemetry/base/structured_parsing/struct_plugin_executions.sql
+++ b/data/transform/models/marts/telemetry/base/structured_parsing/struct_plugin_executions.sql
@@ -33,9 +33,10 @@ SELECT
 FROM {{ ref('structured_executions') }}
 LEFT JOIN
     {{ ref('cmd_parsed_all') }} ON
-        structured_executions.command = cmd_parsed_all.command
+    structured_executions.command = cmd_parsed_all.command
 LEFT JOIN
     {{ ref('struct_plugins') }} ON
-        structured_executions.command = struct_plugins.command
-WHERE cmd_parsed_all.command_type = 'plugin'
+    structured_executions.command = struct_plugins.command
+WHERE
+    cmd_parsed_all.command_type = 'plugin'
     AND struct_plugins.plugin_name IS NOT NULL

--- a/data/transform/models/marts/telemetry/base/unstructured_executions.sql
+++ b/data/transform/models/marts/telemetry/base/unstructured_executions.sql
@@ -10,4 +10,4 @@ SELECT
 FROM {{ ref('unstruct_exec_flattened') }}
 INNER JOIN
     {{ ref('cli_execs_blended') }} ON
-        unstruct_exec_flattened.execution_id = cli_execs_blended.execution_id
+    unstruct_exec_flattened.execution_id = cli_execs_blended.execution_id

--- a/data/transform/models/marts/telemetry/base/unstructured_parsing/context_base.sql
+++ b/data/transform/models/marts/telemetry/base/unstructured_parsing/context_base.sql
@@ -14,7 +14,8 @@ FROM {{ ref('event_unstruct') }},
     LATERAL FLATTEN(
         input => PARSE_JSON(event_unstruct.contexts::VARIANT):data
     ) AS context
-WHERE event_unstruct.contexts IS NOT NULL
+WHERE
+    event_unstruct.contexts IS NOT NULL
     AND context.value:schema::STRING
     != 'iglu:com.snowplowanalytics.snowplow/web_page/jsonschema/1-0-0'
 

--- a/data/transform/models/marts/telemetry/base/unstructured_parsing/context_cli.sql
+++ b/data/transform/models/marts/telemetry/base/unstructured_parsing/context_cli.sql
@@ -24,22 +24,26 @@ base_1_1_0_onward AS (
         MAX(event_created_at) AS event_created_at,
         MAX(context:schema::STRING) AS schema_name,
         MAX(
-            CASE WHEN
-                context:data:command::STRING != 'cli'
-                AND COALESCE(
-                    context:data:parent_command_hint,
-                    'cli'
-                ) = 'cli'
-                THEN context:data:command::STRING END
+            CASE
+                WHEN
+                    context:data:command::STRING != 'cli'
+                    AND COALESCE(
+                        context:data:parent_command_hint,
+                        'cli'
+                    ) = 'cli'
+                    THEN context:data:command::STRING
+            END
         ) AS command,
         MAX(
-            CASE WHEN
-                context:data:command::STRING != 'cli'
-                AND COALESCE(
-                    context:data:parent_command_hint,
-                    'cli'
-                ) != 'cli'
-                THEN context:data:command::STRING END
+            CASE
+                WHEN
+                    context:data:command::STRING != 'cli'
+                    AND COALESCE(
+                        context:data:parent_command_hint,
+                        'cli'
+                    ) != 'cli'
+                    THEN context:data:command::STRING
+            END
         ) AS sub_command,
         OBJECT_AGG(context:data:command, context:data:options) AS options_obj,
         MAX(SPLIT_PART(schema_name, '/', -1)) AS schema_version

--- a/data/transform/models/marts/telemetry/base/unstructured_parsing/unstruct_plugins.sql
+++ b/data/transform/models/marts/telemetry/base/unstructured_parsing/unstruct_plugins.sql
@@ -25,25 +25,32 @@ WITH base AS (
         ) AS command
     FROM {{ ref('unstruct_plugins_base') }}
     LEFT JOIN {{ ref('hash_lookup') }} AS h1
-        ON unstruct_plugins_base.name_hash = h1.hash_value
+        ON
+            unstruct_plugins_base.name_hash = h1.hash_value
             AND h1.category = 'plugin_name'
     LEFT JOIN {{ ref('hash_lookup') }} AS h2
-        ON unstruct_plugins_base.parent_name_hash = h2.hash_value
+        ON
+            unstruct_plugins_base.parent_name_hash = h2.hash_value
             AND h2.category = 'plugin_name'
     LEFT JOIN {{ ref('hash_lookup') }} AS h3
-        ON unstruct_plugins_base.executable_hash = h3.hash_value
+        ON
+            unstruct_plugins_base.executable_hash = h3.hash_value
             AND h3.category = 'plugin_executable'
     LEFT JOIN {{ ref('hash_lookup') }} AS h4
-        ON unstruct_plugins_base.namespace_hash = h4.hash_value
+        ON
+            unstruct_plugins_base.namespace_hash = h4.hash_value
             AND h4.category = 'plugin_namespace'
     LEFT JOIN {{ ref('hash_lookup') }} AS h5
-        ON unstruct_plugins_base.pip_url_hash = h5.hash_value
+        ON
+            unstruct_plugins_base.pip_url_hash = h5.hash_value
             AND h5.category = 'plugin_pip_url'
     LEFT JOIN {{ ref('hash_lookup') }} AS h6
-        ON unstruct_plugins_base.variant_name_hash = h6.hash_value
+        ON
+            unstruct_plugins_base.variant_name_hash = h6.hash_value
             AND h6.category = 'plugin_variant'
     LEFT JOIN {{ ref('hash_lookup') }} AS h7
-        ON SHA2_HEX(unstruct_plugins_base.command) = h7.hash_value
+        ON
+            SHA2_HEX(unstruct_plugins_base.command) = h7.hash_value
             AND h7.category = 'plugin_command'
 )
 
@@ -57,5 +64,6 @@ SELECT
                 'transformers', 'utilities'
             ) AND plugin_name LIKE '%dbt%'
             THEN 'dbt'
-        ELSE parent_name END AS plugin_category
+        ELSE parent_name
+    END AS plugin_category
 FROM base

--- a/data/transform/models/marts/telemetry/daily_active_projects.sql
+++ b/data/transform/models/marts/telemetry/daily_active_projects.sql
@@ -14,9 +14,10 @@ daily_project_active AS (
         base.project_id
     FROM {{ ref('date_dim') }}
     INNER JOIN base
-        ON base.exec_date BETWEEN DATEADD(
-            DAY, -28, date_dim.date_day
-        ) AND date_dim.date_day
+        ON
+            base.exec_date BETWEEN DATEADD(
+                DAY, -28, date_dim.date_day
+            ) AND date_dim.date_day
 ),
 
 project_activity_status AS (
@@ -132,5 +133,6 @@ SELECT
     ) AS eom_reactivated
 FROM base_daily
 LEFT JOIN base_monthly
-    ON base_daily.project_id = base_monthly.project_id
+    ON
+        base_daily.project_id = base_monthly.project_id
         AND base_daily.last_day_of_month = base_monthly.last_day_of_month

--- a/data/transform/models/marts/telemetry/fact_cli_cohorts.sql
+++ b/data/transform/models/marts/telemetry/fact_cli_cohorts.sql
@@ -24,7 +24,7 @@ WITH cohort_snapshots AS (
     FROM {{ ref('cli_executions_base') }}
     LEFT JOIN
         {{ ref('project_dim') }} ON
-            cli_executions_base.project_id = project_dim.project_id
+        cli_executions_base.project_id = project_dim.project_id
     GROUP BY 1, 2
 ),
 

--- a/data/transform/models/marts/telemetry/fact_cli_executions.sql
+++ b/data/transform/models/marts/telemetry/fact_cli_executions.sql
@@ -55,7 +55,8 @@ WITH base AS (
     LEFT JOIN {{ ref('date_dim') }}
         ON cli_executions_base.event_date = date_dim.date_day
     LEFT JOIN {{ ref('ip_address_dim') }}
-        ON cli_executions_base.ip_address_hash = ip_address_dim.ip_address_hash
+        ON
+            cli_executions_base.ip_address_hash = ip_address_dim.ip_address_hash
             AND (
                 ip_address_dim.active_from IS NULL
                 OR cli_executions_base.event_created_at
@@ -64,13 +65,18 @@ WITH base AS (
                 )
             )
     LEFT JOIN {{ ref('daily_active_projects') }}
-        ON cli_executions_base.project_id = daily_active_projects.project_id
+        ON
+            cli_executions_base.project_id = daily_active_projects.project_id
             AND date_dim.date_day = daily_active_projects.date_day
-    LEFT JOIN {{ ref('daily_active_projects') }}
+    LEFT JOIN
+        {{ ref('daily_active_projects') }}
         AS daily_active_projects_eom -- noqa: L031
-        ON cli_executions_base.project_id = daily_active_projects_eom.project_id
-            AND CASE WHEN date_dim.last_day_of_month <= CURRENT_DATE
-                THEN date_dim.last_day_of_month
+        ON
+            cli_executions_base.project_id
+            = daily_active_projects_eom.project_id
+            AND CASE
+                WHEN date_dim.last_day_of_month <= CURRENT_DATE
+                    THEN date_dim.last_day_of_month
                 ELSE date_dim.date_day
             END = daily_active_projects_eom.date_day
 ),
@@ -195,11 +201,14 @@ SELECT
     ) AS monthly_runtime_mins_previous_segment
 FROM base
 LEFT JOIN project_segments_monthly
-    ON base.project_id = project_segments_monthly.project_id
+    ON
+        base.project_id = project_segments_monthly.project_id
         AND base.first_day_of_month
         = project_segments_monthly.first_day_of_month
-LEFT JOIN project_segments_monthly
+LEFT JOIN
+    project_segments_monthly
     AS prev_project_segments_monthly -- noqa: L031
-    ON base.project_id = prev_project_segments_monthly.project_id
+    ON
+        base.project_id = prev_project_segments_monthly.project_id
         AND DATEADD(MONTH, -1, base.first_day_of_month)
         = prev_project_segments_monthly.first_day_of_month

--- a/data/transform/models/marts/telemetry/fact_el_executions.sql
+++ b/data/transform/models/marts/telemetry/fact_el_executions.sql
@@ -10,7 +10,8 @@ WITH base AS (
             WHEN MOD(row_num, 2) = 0 THEN row_num ELSE row_num + 1
         END AS plugin_pair_index
     FROM {{ ref('fact_plugin_usage') }}
-    WHERE plugin_category = 'singer'
+    WHERE
+        plugin_category = 'singer'
         AND plugin_type NOT IN ('mappers', 'transforms', 'UNKNOWN')
         AND cli_command IN ('elt', 'run')
         AND pipeline_fk IS NOT NULL

--- a/data/transform/models/marts/telemetry/fact_plugin_usage.sql
+++ b/data/transform/models/marts/telemetry/fact_plugin_usage.sql
@@ -67,7 +67,8 @@ LEFT JOIN {{ ref('date_dim') }}
 LEFT JOIN {{ ref('project_dim') }}
     ON cli_executions_base.project_id = project_dim.project_id
 LEFT JOIN {{ ref('ip_address_dim') }}
-    ON cli_executions_base.ip_address_hash = ip_address_dim.ip_address_hash
+    ON
+        cli_executions_base.ip_address_hash = ip_address_dim.ip_address_hash
         AND (
             ip_address_dim.active_from IS NULL
             OR cli_executions_base.event_created_at
@@ -78,5 +79,6 @@ LEFT JOIN {{ ref('ip_address_dim') }}
 LEFT JOIN {{ ref('pipeline_executions') }}
     ON cli_executions_base.execution_id = pipeline_executions.execution_id
 LEFT JOIN {{ ref('daily_active_projects') }}
-    ON cli_executions_base.project_id = daily_active_projects.project_id
+    ON
+        cli_executions_base.project_id = daily_active_projects.project_id
         AND date_dim.date_day = daily_active_projects.date_day

--- a/data/transform/models/marts/telemetry/project_dim.sql
+++ b/data/transform/models/marts/telemetry/project_dim.sql
@@ -149,7 +149,8 @@ SELECT
             -- codespace original path - 'PosixPath(\'new_project\')'
             'e5ca2eeb4da09ea1a66c3d9391b5bf43296e309c619c04914ac5bffbb3e7cf54',
             -- updated uuid - 'PosixPath(\'b54c6cfe2f8f831389a5b9ca409f410c\')'
-            '781d839e18d017b347cf90a22e18b407e3cdacb2a9cc907d3693893a790fdc4c'),
+            '781d839e18d017b347cf90a22e18b407e3cdacb2a9cc907d3693893a790fdc4c'
+        ),
         FALSE
     ) AS is_codespace_demo,
     COALESCE(
@@ -157,10 +158,11 @@ SELECT
             -- full GSG tutorial path - 'PosixPath(\'my-meltano-project\')'
             'edd9334eaeaa3b81f964e18c5840955de8791ea220740459f7393deca03085f6',
             -- mulit part GSG tutorial path - 'PosixPath(\'my-new-project\')'
-            'ffd7f2044d5bf2efc6bd4353979041951c565125c08186e3160be926a6ee1e75'),
+            'ffd7f2044d5bf2efc6bd4353979041951c565125c08186e3160be926a6ee1e75'
+        ),
         FALSE
     ) AS is_gsg_tutorial
 FROM {{ ref('project_base') }}
 LEFT JOIN
     active_projects ON
-        project_base.project_id = active_projects.project_id
+    project_base.project_id = active_projects.project_id

--- a/data/transform/models/marts/telemetry/project_plugins.sql
+++ b/data/transform/models/marts/telemetry/project_plugins.sql
@@ -7,62 +7,74 @@ plugins_per_project AS (
     SELECT
         date_dim.date_day,
         (
-            SELECT COUNT(
-                DISTINCT plugins.project_id
-            )
+            SELECT
+                COUNT(
+                    DISTINCT plugins.project_id
+                )
             FROM plugins
-            WHERE plugins.date_day BETWEEN DATEADD(
+            WHERE
+                plugins.date_day BETWEEN DATEADD(
                     DAY, -28, date_dim.date_day
                 ) AND date_dim.date_day
         ) AS projects_28d,
         (
-            SELECT COUNT(
-                DISTINCT
-                plugins.project_id,
-                plugins.plugin_category
-            )
+            SELECT
+                COUNT(
+                    DISTINCT
+                    plugins.project_id,
+                    plugins.plugin_category
+                )
             FROM plugins
-            WHERE plugins.date_day BETWEEN DATEADD(
+            WHERE
+                plugins.date_day BETWEEN DATEADD(
                     DAY, -28, date_dim.date_day
                 ) AND date_dim.date_day
         ) AS plugin_categories_28d,
         (
-            SELECT COUNT(
-                DISTINCT plugins.project_id
-            )
+            SELECT
+                COUNT(
+                    DISTINCT plugins.project_id
+                )
             FROM plugins
-            WHERE plugins.date_day BETWEEN DATEADD(
+            WHERE
+                plugins.date_day BETWEEN DATEADD(
                     DAY, -14, date_dim.date_day
                 ) AND date_dim.date_day
         ) AS projects_14d,
         (
-            SELECT COUNT(
-                DISTINCT
-                plugins.project_id,
-                plugins.plugin_category
-            )
+            SELECT
+                COUNT(
+                    DISTINCT
+                    plugins.project_id,
+                    plugins.plugin_category
+                )
             FROM plugins
-            WHERE plugins.date_day BETWEEN DATEADD(
+            WHERE
+                plugins.date_day BETWEEN DATEADD(
                     DAY, -14, date_dim.date_day
                 ) AND date_dim.date_day
         ) AS plugin_categories_14d,
         (
-            SELECT COUNT(
-                DISTINCT plugins.project_id
-            )
+            SELECT
+                COUNT(
+                    DISTINCT plugins.project_id
+                )
             FROM plugins
-            WHERE plugins.date_day BETWEEN DATEADD(
+            WHERE
+                plugins.date_day BETWEEN DATEADD(
                     DAY, -7, date_dim.date_day
                 ) AND date_dim.date_day
         ) AS projects_7d,
         (
-            SELECT COUNT(
-                DISTINCT
-                plugins.project_id,
-                plugins.plugin_category
-            )
+            SELECT
+                COUNT(
+                    DISTINCT
+                    plugins.project_id,
+                    plugins.plugin_category
+                )
             FROM plugins
-            WHERE plugins.date_day BETWEEN DATEADD(
+            WHERE
+                plugins.date_day BETWEEN DATEADD(
                     DAY, -7, date_dim.date_day
                 ) AND date_dim.date_day
         ) AS plugin_categories_7d

--- a/data/transform/models/publish/meltano_hub/fact_hub_metrics.sql
+++ b/data/transform/models/publish/meltano_hub/fact_hub_metrics.sql
@@ -5,7 +5,8 @@ WITH plugin_use_3m AS (
         SUM(event_count) AS execution_count,
         COUNT(DISTINCT project_id) AS project_count
     FROM {{ ref('fact_plugin_usage') }}
-    WHERE plugin_category = 'singer'
+    WHERE
+        plugin_category = 'singer'
         AND COALESCE(
             cli_started_ts, cli_finished_ts
         ) >= DATEADD(MONTH, -3, CURRENT_DATE)
@@ -29,11 +30,12 @@ rename_join AS (
         COALESCE(plugin_use_3m.project_count, 0) AS meltano_project_id_count_3m
     FROM {{ ref('fact_repo_metrics') }}
     LEFT JOIN plugin_use_3m
-        ON REPLACE(
-            fact_repo_metrics.repo_name,
-            'pipelinewise-',
-            ''
-        ) = plugin_use_3m.plugin_name
+        ON
+            REPLACE(
+                fact_repo_metrics.repo_name,
+                'pipelinewise-',
+                ''
+            ) = plugin_use_3m.plugin_name
 
 )
 

--- a/data/transform/models/publish/meltano_hub/fact_variant_hub_metrics.sql
+++ b/data/transform/models/publish/meltano_hub/fact_variant_hub_metrics.sql
@@ -41,17 +41,23 @@ agg_all_by_name AS (
         END AS plugin_name,
         COUNT(DISTINCT project_id) AS all_projects,
         COUNT(
-            DISTINCT CASE WHEN
-                is_success AND is_exec
-                THEN project_id END
+            DISTINCT CASE
+                WHEN
+                    is_success AND is_exec
+                    THEN project_id
+            END
         ) AS success_projects,
         SUM(
-            CASE WHEN is_success AND is_exec
-                THEN event_count END
+            CASE
+                WHEN is_success AND is_exec
+                    THEN event_count
+            END
         ) AS success_execs,
         SUM(
-            CASE WHEN is_exec
-                THEN event_count END
+            CASE
+                WHEN is_exec
+                    THEN event_count
+            END
         ) AS all_execs
     FROM base
     WHERE plugin_category = 'singer'
@@ -68,7 +74,8 @@ unstruct_base AS (
         base.is_exec,
         base.project_id,
         base.event_count
-    FROM {{ ref('stg_meltanohub__plugins') }}
+    FROM
+        {{ ref('stg_meltanohub__plugins') }}
     -- Usage is attributed if the variant matches whats on the hub or if the
     -- pip_url matches but the variant does not. That accounts for the
     -- `original` variant case where the python package is the same but the
@@ -94,17 +101,23 @@ agg_unstruct_by_name AS (
         plugin_type,
         COUNT(DISTINCT project_id) AS all_projects,
         COUNT(
-            DISTINCT CASE WHEN
-                is_success AND is_exec
-                THEN project_id END
+            DISTINCT CASE
+                WHEN
+                    is_success AND is_exec
+                    THEN project_id
+            END
         ) AS success_projects,
         SUM(
-            CASE WHEN is_success AND is_exec
-                THEN event_count END
+            CASE
+                WHEN is_success AND is_exec
+                    THEN event_count
+            END
         ) AS success_execs,
         SUM(
-            CASE WHEN is_exec
-                THEN event_count END
+            CASE
+                WHEN is_exec
+                    THEN event_count
+            END
         ) AS all_execs
     FROM base
     WHERE event_type = 'unstructured'
@@ -118,17 +131,23 @@ agg_unstruct_by_variant AS (
         variant,
         COUNT(DISTINCT project_id) AS all_projects,
         COUNT(
-            DISTINCT CASE WHEN
-                is_success AND is_exec
-                THEN project_id END
+            DISTINCT CASE
+                WHEN
+                    is_success AND is_exec
+                    THEN project_id
+            END
         ) AS success_projects,
         SUM(
-            CASE WHEN is_success AND is_exec
-                THEN event_count END
+            CASE
+                WHEN is_success AND is_exec
+                    THEN event_count
+            END
         ) AS success_execs,
         SUM(
-            CASE WHEN is_exec
-                THEN event_count END
+            CASE
+                WHEN is_exec
+                    THEN event_count
+            END
         ) AS all_execs
     FROM unstruct_base
     GROUP BY 1, 2, 3
@@ -175,26 +194,30 @@ final AS (
         ) AS success_execs_unstruct_by_variant
     FROM {{ ref('stg_meltanohub__plugins') }}
     LEFT JOIN agg_unstruct_by_variant
-        ON agg_unstruct_by_variant.name = stg_meltanohub__plugins.name
+        ON
+            agg_unstruct_by_variant.name = stg_meltanohub__plugins.name
             AND agg_unstruct_by_variant.plugin_type
             = stg_meltanohub__plugins.plugin_type
             AND agg_unstruct_by_variant.variant
             = stg_meltanohub__plugins.variant
     LEFT JOIN agg_unstruct_by_name
-        ON agg_unstruct_by_name.plugin_name
+        ON
+            agg_unstruct_by_name.plugin_name
             = stg_meltanohub__plugins.name
             AND agg_unstruct_by_name.plugin_type
             = stg_meltanohub__plugins.plugin_type
     LEFT JOIN {{ ref('fact_repo_metrics') }}
-        ON LOWER(stg_meltanohub__plugins.repo) = LOWER(
-            'https://github.com/' || fact_repo_metrics.repo_full_name
-        )
+        ON
+            LOWER(stg_meltanohub__plugins.repo) = LOWER(
+                'https://github.com/' || fact_repo_metrics.repo_full_name
+            )
     LEFT JOIN agg_all_by_name
-        ON REPLACE(
-            fact_repo_metrics.repo_name,
-            'pipelinewise-',
-            ''
-        ) = agg_all_by_name.plugin_name
+        ON
+            REPLACE(
+                fact_repo_metrics.repo_name,
+                'pipelinewise-',
+                ''
+            ) = agg_all_by_name.plugin_name
 )
 
 SELECT

--- a/data/transform/models/publish/meltano_hub/hub_bot_plugins.sql
+++ b/data/transform/models/publish/meltano_hub/hub_bot_plugins.sql
@@ -36,7 +36,8 @@ SELECT
         'capabilities',
         CASE
             WHEN
-                stg_github_search__repositories.connector_type = 'tap' THEN [
+                stg_github_search__repositories.connector_type = 'tap' THEN
+                [
                     'catalog', 'discover', 'state'
                 ]
             ELSE []
@@ -54,15 +55,16 @@ SELECT
 FROM {{ ref('stg_github_search__repositories') }}
 LEFT JOIN
     {{ ref('stg_meltanohub__plugins') }} ON
-        stg_github_search__repositories.repo_url = stg_meltanohub__plugins.repo
+    stg_github_search__repositories.repo_url = stg_meltanohub__plugins.repo
 LEFT JOIN
     {{ ref('hub_repos_to_exclude') }} ON
-        stg_github_search__repositories.repo_url = hub_repos_to_exclude.repo_url
+    stg_github_search__repositories.repo_url = hub_repos_to_exclude.repo_url
 LEFT JOIN
     {{ ref('stg_github_search__readme') }} ON
-        stg_github_search__repositories.repo_url
-        = stg_github_search__readme.repo_url
-WHERE stg_github_search__repositories.visibility = 'public'
+    stg_github_search__repositories.repo_url
+    = stg_github_search__readme.repo_url
+WHERE
+    stg_github_search__repositories.visibility = 'public'
     AND stg_github_search__repositories.is_disabled = FALSE
     AND stg_github_search__repositories.is_archived = FALSE
     AND stg_github_search__repositories.size_kb > 30

--- a/data/transform/models/publish/slack_notifications/github_activity_notifications.sql
+++ b/data/transform/models/publish/slack_notifications/github_activity_notifications.sql
@@ -21,49 +21,59 @@ WITH most_recent_date AS (
 base AS (
     SELECT
         ARRAY_AGG(
-            CASE WHEN contributions.contribution_type = 'pull_request'
-                AND contributions.state = 'open'
-                AND contributions.created_at_ts::DATE >= DATEADD(
-                    DAY, -1, most_recent_date.max_date
-                )
-                THEN {{ github_activity_slack_message_generator() }}
+            CASE
+                WHEN
+                    contributions.contribution_type = 'pull_request'
+                    AND contributions.state = 'open'
+                    AND contributions.created_at_ts::DATE >= DATEADD(
+                        DAY, -1, most_recent_date.max_date
+                    )
+                    THEN {{ github_activity_slack_message_generator() }}
             END
         ) AS prs_opened,
         ARRAY_AGG(
-            CASE WHEN contributions.contribution_type = 'pull_request'
-                AND contributions.state = 'closed'
-                AND contributions.merged_at_ts::DATE >= DATEADD(
-                    DAY, -1, most_recent_date.max_date
-                )
-                THEN {{ github_activity_slack_message_generator() }}
+            CASE
+                WHEN
+                    contributions.contribution_type = 'pull_request'
+                    AND contributions.state = 'closed'
+                    AND contributions.merged_at_ts::DATE >= DATEADD(
+                        DAY, -1, most_recent_date.max_date
+                    )
+                    THEN {{ github_activity_slack_message_generator() }}
             END
         ) AS prs_merged,
         ARRAY_AGG(
-            CASE WHEN contributions.contribution_type = 'pull_request'
-                AND contributions.state = 'closed'
-                AND contributions.merged_at_ts IS NULL
-                AND contributions.closed_at_ts::DATE >= DATEADD(
-                    DAY, -1, most_recent_date.max_date
-                )
-                THEN {{ github_activity_slack_message_generator() }}
+            CASE
+                WHEN
+                    contributions.contribution_type = 'pull_request'
+                    AND contributions.state = 'closed'
+                    AND contributions.merged_at_ts IS NULL
+                    AND contributions.closed_at_ts::DATE >= DATEADD(
+                        DAY, -1, most_recent_date.max_date
+                    )
+                    THEN {{ github_activity_slack_message_generator() }}
             END
         ) AS prs_closed,
         ARRAY_AGG(
-            CASE WHEN contributions.contribution_type = 'issue'
-                AND contributions.state = 'open'
-                AND contributions.created_at_ts::DATE >= DATEADD(
-                    DAY, -1, most_recent_date.max_date
-                )
-                THEN {{ github_activity_slack_message_generator() }}
+            CASE
+                WHEN
+                    contributions.contribution_type = 'issue'
+                    AND contributions.state = 'open'
+                    AND contributions.created_at_ts::DATE >= DATEADD(
+                        DAY, -1, most_recent_date.max_date
+                    )
+                    THEN {{ github_activity_slack_message_generator() }}
             END
         ) AS issues_opened,
         ARRAY_AGG(
-            CASE WHEN contributions.contribution_type = 'issue'
-                AND contributions.state = 'closed'
-                AND contributions.closed_at_ts::DATE >= DATEADD(
-                    DAY, -1, most_recent_date.max_date
-                )
-                THEN {{ github_activity_slack_message_generator() }}
+            CASE
+                WHEN
+                    contributions.contribution_type = 'issue'
+                    AND contributions.state = 'closed'
+                    AND contributions.closed_at_ts::DATE >= DATEADD(
+                        DAY, -1, most_recent_date.max_date
+                    )
+                    THEN {{ github_activity_slack_message_generator() }}
             END
         ) AS issues_closed
     FROM {{ ref('contributions') }}

--- a/data/transform/models/publish/slack_notifications/github_activity_notifications.sql
+++ b/data/transform/models/publish/slack_notifications/github_activity_notifications.sql
@@ -3,7 +3,8 @@ WITH most_recent_date AS (
 
     {% if env_var("MELTANO_ENVIRONMENT") == "cicd" %}
 
-        SELECT GREATEST(
+        SELECT
+            GREATEST(
                 MAX(created_at_ts),
                 MAX(merged_at_ts),
                 MAX(closed_at_ts)

--- a/data/transform/models/publish/slack_notifications/slack_alerts.sql
+++ b/data/transform/models/publish/slack_notifications/slack_alerts.sql
@@ -3,7 +3,8 @@ WITH most_recent_date AS (
 
     {% if env_var("MELTANO_ENVIRONMENT") == "cicd" %}
 
-        SELECT GREATEST(
+        SELECT
+            GREATEST(
                 MAX(created_at_ts),
                 MAX(pr_merged_at_ts),
                 MAX(closed_at_ts)

--- a/data/transform/models/publish/slack_notifications/slack_alerts.sql
+++ b/data/transform/models/publish/slack_notifications/slack_alerts.sql
@@ -21,49 +21,59 @@ WITH most_recent_date AS (
 base AS (
     SELECT
         ARRAY_AGG(
-            CASE WHEN singer_contributions.contribution_type = 'pull_request'
-                AND singer_contributions.state = 'open'
-                AND singer_contributions.created_at_ts::DATE = DATEADD(
-                    DAY, -1, most_recent_date.max_date
-                )
-                THEN {{ slack_message_generator() }}
+            CASE
+                WHEN
+                    singer_contributions.contribution_type = 'pull_request'
+                    AND singer_contributions.state = 'open'
+                    AND singer_contributions.created_at_ts::DATE = DATEADD(
+                        DAY, -1, most_recent_date.max_date
+                    )
+                    THEN {{ slack_message_generator() }}
             END
         ) AS prs_opened,
         ARRAY_AGG(
-            CASE WHEN singer_contributions.contribution_type = 'pull_request'
-                AND singer_contributions.state = 'closed'
-                AND singer_contributions.pr_merged_at_ts::DATE = DATEADD(
-                    DAY, -1, most_recent_date.max_date
-                )
-                THEN {{ slack_message_generator() }}
+            CASE
+                WHEN
+                    singer_contributions.contribution_type = 'pull_request'
+                    AND singer_contributions.state = 'closed'
+                    AND singer_contributions.pr_merged_at_ts::DATE = DATEADD(
+                        DAY, -1, most_recent_date.max_date
+                    )
+                    THEN {{ slack_message_generator() }}
             END
         ) AS prs_merged,
         ARRAY_AGG(
-            CASE WHEN singer_contributions.contribution_type = 'pull_request'
-                AND singer_contributions.state = 'closed'
-                AND singer_contributions.pr_merged_at_ts IS NULL
-                AND singer_contributions.closed_at_ts::DATE = DATEADD(
-                    DAY, -1, most_recent_date.max_date
-                )
-                THEN {{ slack_message_generator() }}
+            CASE
+                WHEN
+                    singer_contributions.contribution_type = 'pull_request'
+                    AND singer_contributions.state = 'closed'
+                    AND singer_contributions.pr_merged_at_ts IS NULL
+                    AND singer_contributions.closed_at_ts::DATE = DATEADD(
+                        DAY, -1, most_recent_date.max_date
+                    )
+                    THEN {{ slack_message_generator() }}
             END
         ) AS prs_closed,
         ARRAY_AGG(
-            CASE WHEN singer_contributions.contribution_type = 'issue'
-                AND singer_contributions.state = 'open'
-                AND singer_contributions.created_at_ts::DATE = DATEADD(
-                    DAY, -1, most_recent_date.max_date
-                )
-                THEN {{ slack_message_generator() }}
+            CASE
+                WHEN
+                    singer_contributions.contribution_type = 'issue'
+                    AND singer_contributions.state = 'open'
+                    AND singer_contributions.created_at_ts::DATE = DATEADD(
+                        DAY, -1, most_recent_date.max_date
+                    )
+                    THEN {{ slack_message_generator() }}
             END
         ) AS issues_opened,
         ARRAY_AGG(
-            CASE WHEN singer_contributions.contribution_type = 'issue'
-                AND singer_contributions.state = 'closed'
-                AND singer_contributions.closed_at_ts::DATE = DATEADD(
-                    DAY, -1, most_recent_date.max_date
-                )
-                THEN {{ slack_message_generator() }}
+            CASE
+                WHEN
+                    singer_contributions.contribution_type = 'issue'
+                    AND singer_contributions.state = 'closed'
+                    AND singer_contributions.closed_at_ts::DATE = DATEADD(
+                        DAY, -1, most_recent_date.max_date
+                    )
+                    THEN {{ slack_message_generator() }}
             END
         ) AS issues_closed
     FROM {{ ref('singer_contributions') }}
@@ -77,21 +87,23 @@ base AS (
 ),
 
 repos AS (
-    SELECT ARRAY_AGG(
+    SELECT
+        ARRAY_AGG(
             CASE
                 WHEN
                     stg_github_search__repositories.created_at_ts::DATE
                     = DATEADD(
                         DAY, -1, most_recent_date.max_date
                     )
-                    THEN '\n     • <'
-                    || stg_github_search__repositories.repo_url || ' | '
-                    || stg_github_search__repositories.repo_full_name
-                    || '> - _' || COALESCE(
-                        stg_github_search__repositories.description,
-                        'No Description'
-                    )
-                    || '_\n'
+                    THEN
+                        '\n     • <'
+                        || stg_github_search__repositories.repo_url || ' | '
+                        || stg_github_search__repositories.repo_full_name
+                        || '> - _' || COALESCE(
+                            stg_github_search__repositories.description,
+                            'No Description'
+                        )
+                        || '_\n'
 
             END
         ) AS repos_created

--- a/data/transform/models/staging/github_meltano/stg_github__issues.sql
+++ b/data/transform/models/staging/github_meltano/stg_github__issues.sql
@@ -35,7 +35,8 @@ renamed AS (
         assignee:login::STRING AS assignee_username,
         COALESCE(user:type::STRING = 'Bot', FALSE) AS is_bot_user
     FROM source
-    WHERE row_num = 1
+    WHERE
+        row_num = 1
         AND type != 'pull_request'
 
 )

--- a/data/transform/models/staging/github_search/stg_github_search__repositories.sql
+++ b/data/transform/models/staging/github_search/stg_github_search__repositories.sql
@@ -50,8 +50,9 @@ renamed AS (
         SPLIT_PART(full_name, '/', 1) AS repo_namespace,
         DATEDIFF(DAY, created_at, CURRENT_TIMESTAMP()) AS repo_lifespan_days,
         CASE
-            WHEN name LIKE 'tap-%'
-                 OR name LIKE '%-tap-%'
+            WHEN
+                name LIKE 'tap-%'
+                OR name LIKE '%-tap-%'
                 THEN 'tap'
             ELSE 'target'
         END AS connector_type

--- a/data/transform/models/staging/snowplow/snowplow_bad_parsed.sql
+++ b/data/transform/models/staging/snowplow/snowplow_bad_parsed.sql
@@ -7,7 +7,8 @@ WITH reparse_1 AS (
         payload_enriched,
         uploaded_at
     FROM {{ ref('stg_snowplow__events_bad') }}
-    WHERE uploaded_at::date BETWEEN '2023-01-17' AND '2023-02-02'
+    WHERE
+        uploaded_at::date BETWEEN '2023-01-17' AND '2023-02-02'
         AND failure_message[
             0
         ]:schemaKey::string
@@ -24,7 +25,8 @@ reparse_2 AS (
         payload_enriched,
         uploaded_at
     FROM {{ ref('stg_snowplow__events_bad') }}
-    WHERE failure_message[
+    WHERE
+        failure_message[
             0
         ]:schemaKey::string
         = 'iglu:com.meltano/exit_event/jsonschema/1-0-0'
@@ -49,7 +51,8 @@ reparse_3 AS (
             'iglu:com.meltano/exception_context/jsonschema/1-0-0'
         ) AS payload_enriched
     FROM {{ ref('stg_snowplow__events_bad') }}
-    WHERE failure_message[
+    WHERE
+        failure_message[
             0
         ]:schemaKey::string
         = 'iglu:com.meltano/exceptions_context/jsonschema/1-0-0'
@@ -58,177 +61,225 @@ reparse_3 AS (
 
 {% for cte_name in ['reparse_1', 'reparse_2', 'reparse_3'] %}
 
-{%- if not loop.first %}
-UNION ALL
-{% endif -%}
+    {%- if not loop.first %}
+        UNION ALL
+    {% endif -%}
 
-SELECT -- noqa: L034
-    PARSE_JSON(payload_enriched):app_id::string AS app_id,
-    PARSE_JSON(payload_enriched):platform::string AS platform,
-    PARSE_JSON(payload_enriched):etl_tstamp::string AS etl_tstamp,
-    PARSE_JSON(payload_enriched):collector_tstamp::string AS collector_tstamp,
-    PARSE_JSON(
-        payload_enriched
-    ):dvce_created_tstamp::string AS dvce_created_tstamp,
-    PARSE_JSON(payload_enriched):event::string AS event,
-    PARSE_JSON(payload_enriched):event_id::string AS event_id,
-    PARSE_JSON(payload_enriched):txn_id::string AS txn_id,
-    PARSE_JSON(payload_enriched):name_tracker::string AS name_tracker,
-    PARSE_JSON(payload_enriched):v_tracker::string AS v_tracker,
-    PARSE_JSON(payload_enriched):v_collector::string AS v_collector,
-    PARSE_JSON(payload_enriched):v_etl::string AS v_etl,
-    PARSE_JSON(payload_enriched):user_id::string AS user_id,
-    PARSE_JSON(payload_enriched):user_ipaddress::string AS user_ipaddress,
-    PARSE_JSON(payload_enriched):user_fingerprint::string AS user_fingerprint,
-    PARSE_JSON(payload_enriched):domain_userid::string AS domain_userid,
-    PARSE_JSON(payload_enriched):domain_sessionidx::string AS domain_sessionidx,
-    PARSE_JSON(payload_enriched):network_userid::string AS network_userid,
-    PARSE_JSON(payload_enriched):geo_country::string AS geo_country,
-    PARSE_JSON(payload_enriched):geo_region::string AS geo_region,
-    PARSE_JSON(payload_enriched):geo_city::string AS geo_city,
-    PARSE_JSON(payload_enriched):geo_zipcode::string AS geo_zipcode,
-    PARSE_JSON(payload_enriched):geo_latitude::string AS geo_latitude,
-    PARSE_JSON(payload_enriched):geo_longitude::string AS geo_longitude,
-    PARSE_JSON(payload_enriched):geo_region_name::string AS geo_region_name,
-    PARSE_JSON(payload_enriched):ip_isp::string AS ip_isp,
-    PARSE_JSON(payload_enriched):ip_organization::string AS ip_organization,
-    PARSE_JSON(payload_enriched):ip_domain::string AS ip_domain,
-    PARSE_JSON(payload_enriched):ip_netspeed::string AS ip_netspeed,
-    PARSE_JSON(payload_enriched):page_url::string AS page_url,
-    PARSE_JSON(payload_enriched):page_title::string AS page_title,
-    PARSE_JSON(payload_enriched):page_referrer::string AS page_referrer,
-    PARSE_JSON(payload_enriched):page_urlscheme::string AS page_urlscheme,
-    PARSE_JSON(payload_enriched):page_urlhost::string AS page_urlhost,
-    PARSE_JSON(payload_enriched):page_urlport::string AS page_urlport,
-    PARSE_JSON(payload_enriched):page_urlpath::string AS page_urlpath,
-    PARSE_JSON(payload_enriched):page_urlquery::string AS page_urlquery,
-    PARSE_JSON(payload_enriched):page_urlfragment::string AS page_urlfragment,
-    PARSE_JSON(payload_enriched):refr_urlscheme::string AS refr_urlscheme,
-    PARSE_JSON(payload_enriched):refr_urlhost::string AS refr_urlhost,
-    PARSE_JSON(payload_enriched):refr_urlport::string AS refr_urlport,
-    PARSE_JSON(payload_enriched):refr_urlpath::string AS refr_urlpath,
-    PARSE_JSON(payload_enriched):refr_urlquery::string AS refr_urlquery,
-    PARSE_JSON(payload_enriched):refr_urlfragment::string AS refr_urlfragment,
-    PARSE_JSON(payload_enriched):refr_medium::string AS refr_medium,
-    PARSE_JSON(payload_enriched):refr_source::string AS refr_source,
-    PARSE_JSON(payload_enriched):refr_term::string AS refr_term,
-    PARSE_JSON(payload_enriched):mkt_medium::string AS mkt_medium,
-    PARSE_JSON(payload_enriched):mkt_source::string AS mkt_source,
-    PARSE_JSON(payload_enriched):mkt_term::string AS mkt_term,
-    PARSE_JSON(payload_enriched):mkt_content::string AS mkt_content,
-    PARSE_JSON(payload_enriched):mkt_campaign::string AS mkt_campaign,
-    PARSE_JSON(payload_enriched):contexts::string AS contexts,
-    PARSE_JSON(payload_enriched):se_category::string AS se_category,
-    PARSE_JSON(payload_enriched):se_action::string AS se_action,
-    PARSE_JSON(payload_enriched):se_label::string AS se_label,
-    PARSE_JSON(payload_enriched):se_property::string AS se_property,
-    PARSE_JSON(payload_enriched):se_value::string AS se_value,
-    PARSE_JSON(payload_enriched):unstruct_event::string AS unstruct_event,
-    PARSE_JSON(payload_enriched):tr_orderid::string AS tr_orderid,
-    PARSE_JSON(payload_enriched):tr_affiliation::string AS tr_affiliation,
-    PARSE_JSON(payload_enriched):tr_total::string AS tr_total,
-    PARSE_JSON(payload_enriched):tr_tax::string AS tr_tax,
-    PARSE_JSON(payload_enriched):tr_shipping::string AS tr_shipping,
-    PARSE_JSON(payload_enriched):tr_city::string AS tr_city,
-    PARSE_JSON(payload_enriched):tr_state::string AS tr_state,
-    PARSE_JSON(payload_enriched):tr_country::string AS tr_country,
-    PARSE_JSON(payload_enriched):ti_orderid::string AS ti_orderid,
-    PARSE_JSON(payload_enriched):ti_sku::string AS ti_sku,
-    PARSE_JSON(payload_enriched):ti_name::string AS ti_name,
-    PARSE_JSON(payload_enriched):ti_category::string AS ti_category,
-    PARSE_JSON(payload_enriched):ti_price::string AS ti_price,
-    PARSE_JSON(payload_enriched):ti_quantity::string AS ti_quantity,
-    PARSE_JSON(payload_enriched):pp_xoffset_min::string AS pp_xoffset_min,
-    PARSE_JSON(payload_enriched):pp_xoffset_max::string AS pp_xoffset_max,
-    PARSE_JSON(payload_enriched):pp_yoffset_min::string AS pp_yoffset_min,
-    PARSE_JSON(payload_enriched):pp_yoffset_max::string AS pp_yoffset_max,
-    PARSE_JSON(payload_enriched):useragent::string AS useragent,
-    PARSE_JSON(payload_enriched):br_name::string AS br_name,
-    PARSE_JSON(payload_enriched):br_family::string AS br_family,
-    PARSE_JSON(payload_enriched):br_version::string AS br_version,
-    PARSE_JSON(payload_enriched):br_type::string AS br_type,
-    PARSE_JSON(payload_enriched):br_renderengine::string AS br_renderengine,
-    PARSE_JSON(payload_enriched):br_lang::string AS br_lang,
-    PARSE_JSON(payload_enriched):br_features_pdf::string AS br_features_pdf,
-    PARSE_JSON(payload_enriched):br_features_flash::string AS br_features_flash,
-    PARSE_JSON(payload_enriched):br_features_java::string AS br_features_java,
-    PARSE_JSON(
-        payload_enriched
-    ):br_features_director::string AS br_features_director,
-    PARSE_JSON(
-        payload_enriched
-    ):br_features_quicktime::string AS br_features_quicktime,
-    PARSE_JSON(
-        payload_enriched
-    ):br_features_realplayer::string AS br_features_realplayer,
-    PARSE_JSON(
-        payload_enriched
-    ):br_features_windowsmedia::string AS br_features_windowsmedia,
-    PARSE_JSON(payload_enriched):br_features_gears::string AS br_features_gears,
-    PARSE_JSON(
-        payload_enriched
-    ):br_features_silverlight::string AS br_features_silverlight,
-    PARSE_JSON(payload_enriched):br_cookies::string AS br_cookies,
-    PARSE_JSON(payload_enriched):br_colordepth::string AS br_colordepth,
-    PARSE_JSON(payload_enriched):br_viewwidth::string AS br_viewwidth,
-    PARSE_JSON(payload_enriched):br_viewheight::string AS br_viewheight,
-    PARSE_JSON(payload_enriched):os_name::string AS os_name,
-    PARSE_JSON(payload_enriched):os_family::string AS os_family,
-    PARSE_JSON(payload_enriched):os_manufacturer::string AS os_manufacturer,
-    PARSE_JSON(payload_enriched):os_timezone::string AS os_timezone,
-    PARSE_JSON(payload_enriched):dvce_type::string AS dvce_type,
-    PARSE_JSON(payload_enriched):dvce_ismobile::string AS dvce_ismobile,
-    PARSE_JSON(payload_enriched):dvce_screenwidth::string AS dvce_screenwidth,
-    PARSE_JSON(payload_enriched):dvce_screenheight::string AS dvce_screenheight,
-    PARSE_JSON(payload_enriched):doc_charset::string AS doc_charset,
-    PARSE_JSON(payload_enriched):doc_width::string AS doc_width,
-    PARSE_JSON(payload_enriched):doc_height::string AS doc_height,
-    PARSE_JSON(payload_enriched):tr_currency::string AS tr_currency,
-    PARSE_JSON(payload_enriched):tr_total_base::string AS tr_total_base,
-    PARSE_JSON(payload_enriched):tr_tax_base::string AS tr_tax_base,
-    PARSE_JSON(payload_enriched):tr_shipping_base::string AS tr_shipping_base,
-    PARSE_JSON(payload_enriched):ti_currency::string AS ti_currency,
-    PARSE_JSON(payload_enriched):ti_price_base::string AS ti_price_base,
-    PARSE_JSON(payload_enriched):base_currency::string AS base_currency,
-    PARSE_JSON(payload_enriched):geo_timezone::string AS geo_timezone,
-    PARSE_JSON(payload_enriched):mkt_clickid::string AS mkt_clickid,
-    PARSE_JSON(payload_enriched):mkt_network::string AS mkt_network,
-    PARSE_JSON(payload_enriched):etl_tags::string AS etl_tags,
-    PARSE_JSON(payload_enriched):dvce_sent_tstamp::string AS dvce_sent_tstamp,
-    PARSE_JSON(
-        payload_enriched
-    ):refr_domain_userid::string AS refr_domain_userid,
-    PARSE_JSON(payload_enriched):refr_dvce_tstamp::string AS refr_dvce_tstamp,
-    PARSE_JSON(payload_enriched):derived_contexts::string AS derived_contexts,
-    PARSE_JSON(payload_enriched):domain_sessionid::string AS domain_sessionid,
-    collector_tstamp AS derived_tstamp,
-    CASE WHEN unstruct_event IS NULL THEN 'com.google.analytics' ELSE
-        SPLIT_PART(
-            SPLIT_PART(PARSE_JSON(unstruct_event):data:schema::string, ':', 2),
-            '/',
-            1
-        ) END AS event_vendor,
-    CASE WHEN unstruct_event IS NULL THEN 'event' ELSE
-        SPLIT_PART(
-            SPLIT_PART(PARSE_JSON(unstruct_event):data:schema::string, ':', 2),
-            '/',
-            2
-        ) END AS event_name,
-    CASE WHEN unstruct_event IS NULL THEN 'jsonschema' ELSE
-        SPLIT_PART(
-            SPLIT_PART(PARSE_JSON(unstruct_event):data:schema::string, ':', 2),
-            '/',
-            3
-        ) END AS event_format,
-    CASE WHEN unstruct_event IS NULL THEN '1-0-0' ELSE
-        SPLIT_PART(
-            SPLIT_PART(PARSE_JSON(unstruct_event):data:schema::string, ':', 2),
-            '/',
-            4
-        ) END AS event_version,
-    PARSE_JSON(payload_enriched):event_fingerprint::string AS event_fingerprint,
-    PARSE_JSON(payload_enriched):true_tstamp::string AS true_tstamp,
-    uploaded_at
-FROM {{ cte_name }}
+    SELECT -- noqa: L034
+        PARSE_JSON(payload_enriched):app_id::string AS app_id,
+        PARSE_JSON(payload_enriched):platform::string AS platform,
+        PARSE_JSON(payload_enriched):etl_tstamp::string AS etl_tstamp,
+        PARSE_JSON(
+            payload_enriched
+        ):collector_tstamp::string AS collector_tstamp,
+        PARSE_JSON(
+            payload_enriched
+        ):dvce_created_tstamp::string AS dvce_created_tstamp,
+        PARSE_JSON(payload_enriched):event::string AS event,
+        PARSE_JSON(payload_enriched):event_id::string AS event_id,
+        PARSE_JSON(payload_enriched):txn_id::string AS txn_id,
+        PARSE_JSON(payload_enriched):name_tracker::string AS name_tracker,
+        PARSE_JSON(payload_enriched):v_tracker::string AS v_tracker,
+        PARSE_JSON(payload_enriched):v_collector::string AS v_collector,
+        PARSE_JSON(payload_enriched):v_etl::string AS v_etl,
+        PARSE_JSON(payload_enriched):user_id::string AS user_id,
+        PARSE_JSON(payload_enriched):user_ipaddress::string AS user_ipaddress,
+        PARSE_JSON(
+            payload_enriched
+        ):user_fingerprint::string AS user_fingerprint,
+        PARSE_JSON(payload_enriched):domain_userid::string AS domain_userid,
+        PARSE_JSON(
+            payload_enriched
+        ):domain_sessionidx::string AS domain_sessionidx,
+        PARSE_JSON(payload_enriched):network_userid::string AS network_userid,
+        PARSE_JSON(payload_enriched):geo_country::string AS geo_country,
+        PARSE_JSON(payload_enriched):geo_region::string AS geo_region,
+        PARSE_JSON(payload_enriched):geo_city::string AS geo_city,
+        PARSE_JSON(payload_enriched):geo_zipcode::string AS geo_zipcode,
+        PARSE_JSON(payload_enriched):geo_latitude::string AS geo_latitude,
+        PARSE_JSON(payload_enriched):geo_longitude::string AS geo_longitude,
+        PARSE_JSON(payload_enriched):geo_region_name::string AS geo_region_name,
+        PARSE_JSON(payload_enriched):ip_isp::string AS ip_isp,
+        PARSE_JSON(payload_enriched):ip_organization::string AS ip_organization,
+        PARSE_JSON(payload_enriched):ip_domain::string AS ip_domain,
+        PARSE_JSON(payload_enriched):ip_netspeed::string AS ip_netspeed,
+        PARSE_JSON(payload_enriched):page_url::string AS page_url,
+        PARSE_JSON(payload_enriched):page_title::string AS page_title,
+        PARSE_JSON(payload_enriched):page_referrer::string AS page_referrer,
+        PARSE_JSON(payload_enriched):page_urlscheme::string AS page_urlscheme,
+        PARSE_JSON(payload_enriched):page_urlhost::string AS page_urlhost,
+        PARSE_JSON(payload_enriched):page_urlport::string AS page_urlport,
+        PARSE_JSON(payload_enriched):page_urlpath::string AS page_urlpath,
+        PARSE_JSON(payload_enriched):page_urlquery::string AS page_urlquery,
+        PARSE_JSON(
+            payload_enriched
+        ):page_urlfragment::string AS page_urlfragment,
+        PARSE_JSON(payload_enriched):refr_urlscheme::string AS refr_urlscheme,
+        PARSE_JSON(payload_enriched):refr_urlhost::string AS refr_urlhost,
+        PARSE_JSON(payload_enriched):refr_urlport::string AS refr_urlport,
+        PARSE_JSON(payload_enriched):refr_urlpath::string AS refr_urlpath,
+        PARSE_JSON(payload_enriched):refr_urlquery::string AS refr_urlquery,
+        PARSE_JSON(
+            payload_enriched
+        ):refr_urlfragment::string AS refr_urlfragment,
+        PARSE_JSON(payload_enriched):refr_medium::string AS refr_medium,
+        PARSE_JSON(payload_enriched):refr_source::string AS refr_source,
+        PARSE_JSON(payload_enriched):refr_term::string AS refr_term,
+        PARSE_JSON(payload_enriched):mkt_medium::string AS mkt_medium,
+        PARSE_JSON(payload_enriched):mkt_source::string AS mkt_source,
+        PARSE_JSON(payload_enriched):mkt_term::string AS mkt_term,
+        PARSE_JSON(payload_enriched):mkt_content::string AS mkt_content,
+        PARSE_JSON(payload_enriched):mkt_campaign::string AS mkt_campaign,
+        PARSE_JSON(payload_enriched):contexts::string AS contexts,
+        PARSE_JSON(payload_enriched):se_category::string AS se_category,
+        PARSE_JSON(payload_enriched):se_action::string AS se_action,
+        PARSE_JSON(payload_enriched):se_label::string AS se_label,
+        PARSE_JSON(payload_enriched):se_property::string AS se_property,
+        PARSE_JSON(payload_enriched):se_value::string AS se_value,
+        PARSE_JSON(payload_enriched):unstruct_event::string AS unstruct_event,
+        PARSE_JSON(payload_enriched):tr_orderid::string AS tr_orderid,
+        PARSE_JSON(payload_enriched):tr_affiliation::string AS tr_affiliation,
+        PARSE_JSON(payload_enriched):tr_total::string AS tr_total,
+        PARSE_JSON(payload_enriched):tr_tax::string AS tr_tax,
+        PARSE_JSON(payload_enriched):tr_shipping::string AS tr_shipping,
+        PARSE_JSON(payload_enriched):tr_city::string AS tr_city,
+        PARSE_JSON(payload_enriched):tr_state::string AS tr_state,
+        PARSE_JSON(payload_enriched):tr_country::string AS tr_country,
+        PARSE_JSON(payload_enriched):ti_orderid::string AS ti_orderid,
+        PARSE_JSON(payload_enriched):ti_sku::string AS ti_sku,
+        PARSE_JSON(payload_enriched):ti_name::string AS ti_name,
+        PARSE_JSON(payload_enriched):ti_category::string AS ti_category,
+        PARSE_JSON(payload_enriched):ti_price::string AS ti_price,
+        PARSE_JSON(payload_enriched):ti_quantity::string AS ti_quantity,
+        PARSE_JSON(payload_enriched):pp_xoffset_min::string AS pp_xoffset_min,
+        PARSE_JSON(payload_enriched):pp_xoffset_max::string AS pp_xoffset_max,
+        PARSE_JSON(payload_enriched):pp_yoffset_min::string AS pp_yoffset_min,
+        PARSE_JSON(payload_enriched):pp_yoffset_max::string AS pp_yoffset_max,
+        PARSE_JSON(payload_enriched):useragent::string AS useragent,
+        PARSE_JSON(payload_enriched):br_name::string AS br_name,
+        PARSE_JSON(payload_enriched):br_family::string AS br_family,
+        PARSE_JSON(payload_enriched):br_version::string AS br_version,
+        PARSE_JSON(payload_enriched):br_type::string AS br_type,
+        PARSE_JSON(payload_enriched):br_renderengine::string AS br_renderengine,
+        PARSE_JSON(payload_enriched):br_lang::string AS br_lang,
+        PARSE_JSON(payload_enriched):br_features_pdf::string AS br_features_pdf,
+        PARSE_JSON(
+            payload_enriched
+        ):br_features_flash::string AS br_features_flash,
+        PARSE_JSON(
+            payload_enriched
+        ):br_features_java::string AS br_features_java,
+        PARSE_JSON(
+            payload_enriched
+        ):br_features_director::string AS br_features_director,
+        PARSE_JSON(
+            payload_enriched
+        ):br_features_quicktime::string AS br_features_quicktime,
+        PARSE_JSON(
+            payload_enriched
+        ):br_features_realplayer::string AS br_features_realplayer,
+        PARSE_JSON(
+            payload_enriched
+        ):br_features_windowsmedia::string AS br_features_windowsmedia,
+        PARSE_JSON(
+            payload_enriched
+        ):br_features_gears::string AS br_features_gears,
+        PARSE_JSON(
+            payload_enriched
+        ):br_features_silverlight::string AS br_features_silverlight,
+        PARSE_JSON(payload_enriched):br_cookies::string AS br_cookies,
+        PARSE_JSON(payload_enriched):br_colordepth::string AS br_colordepth,
+        PARSE_JSON(payload_enriched):br_viewwidth::string AS br_viewwidth,
+        PARSE_JSON(payload_enriched):br_viewheight::string AS br_viewheight,
+        PARSE_JSON(payload_enriched):os_name::string AS os_name,
+        PARSE_JSON(payload_enriched):os_family::string AS os_family,
+        PARSE_JSON(payload_enriched):os_manufacturer::string AS os_manufacturer,
+        PARSE_JSON(payload_enriched):os_timezone::string AS os_timezone,
+        PARSE_JSON(payload_enriched):dvce_type::string AS dvce_type,
+        PARSE_JSON(payload_enriched):dvce_ismobile::string AS dvce_ismobile,
+        PARSE_JSON(
+            payload_enriched
+        ):dvce_screenwidth::string AS dvce_screenwidth,
+        PARSE_JSON(
+            payload_enriched
+        ):dvce_screenheight::string AS dvce_screenheight,
+        PARSE_JSON(payload_enriched):doc_charset::string AS doc_charset,
+        PARSE_JSON(payload_enriched):doc_width::string AS doc_width,
+        PARSE_JSON(payload_enriched):doc_height::string AS doc_height,
+        PARSE_JSON(payload_enriched):tr_currency::string AS tr_currency,
+        PARSE_JSON(payload_enriched):tr_total_base::string AS tr_total_base,
+        PARSE_JSON(payload_enriched):tr_tax_base::string AS tr_tax_base,
+        PARSE_JSON(
+            payload_enriched
+        ):tr_shipping_base::string AS tr_shipping_base,
+        PARSE_JSON(payload_enriched):ti_currency::string AS ti_currency,
+        PARSE_JSON(payload_enriched):ti_price_base::string AS ti_price_base,
+        PARSE_JSON(payload_enriched):base_currency::string AS base_currency,
+        PARSE_JSON(payload_enriched):geo_timezone::string AS geo_timezone,
+        PARSE_JSON(payload_enriched):mkt_clickid::string AS mkt_clickid,
+        PARSE_JSON(payload_enriched):mkt_network::string AS mkt_network,
+        PARSE_JSON(payload_enriched):etl_tags::string AS etl_tags,
+        PARSE_JSON(
+            payload_enriched
+        ):dvce_sent_tstamp::string AS dvce_sent_tstamp,
+        PARSE_JSON(
+            payload_enriched
+        ):refr_domain_userid::string AS refr_domain_userid,
+        PARSE_JSON(
+            payload_enriched
+        ):refr_dvce_tstamp::string AS refr_dvce_tstamp,
+        PARSE_JSON(
+            payload_enriched
+        ):derived_contexts::string AS derived_contexts,
+        PARSE_JSON(
+            payload_enriched
+        ):domain_sessionid::string AS domain_sessionid,
+        collector_tstamp AS derived_tstamp,
+        CASE
+            WHEN unstruct_event IS NULL THEN 'com.google.analytics' ELSE
+                SPLIT_PART(
+                    SPLIT_PART(
+                        PARSE_JSON(unstruct_event):data:schema::string, ':', 2
+                    ),
+                    '/',
+                    1
+                )
+        END AS event_vendor,
+        CASE
+            WHEN unstruct_event IS NULL THEN 'event' ELSE
+                SPLIT_PART(
+                    SPLIT_PART(
+                        PARSE_JSON(unstruct_event):data:schema::string, ':', 2
+                    ),
+                    '/',
+                    2
+                )
+        END AS event_name,
+        CASE
+            WHEN unstruct_event IS NULL THEN 'jsonschema' ELSE
+                SPLIT_PART(
+                    SPLIT_PART(
+                        PARSE_JSON(unstruct_event):data:schema::string, ':', 2
+                    ),
+                    '/',
+                    3
+                )
+        END AS event_format,
+        CASE
+            WHEN unstruct_event IS NULL THEN '1-0-0' ELSE
+                SPLIT_PART(
+                    SPLIT_PART(
+                        PARSE_JSON(unstruct_event):data:schema::string, ':', 2
+                    ),
+                    '/',
+                    4
+                )
+        END AS event_version,
+        PARSE_JSON(
+            payload_enriched
+        ):event_fingerprint::string AS event_fingerprint,
+        PARSE_JSON(payload_enriched):true_tstamp::string AS true_tstamp,
+        uploaded_at
+    FROM {{ cte_name }}
 
 {% endfor %}

--- a/data/transform/models/staging/snowplow/stg_snowplow__events.sql
+++ b/data/transform/models/staging/snowplow/stg_snowplow__events.sql
@@ -23,13 +23,13 @@ WITH blended_source AS (
         {% endif %}
         {% endif %}
 
-        UNION ALL
+    UNION ALL
 
-        SELECT
-            *,
-            TRUE AS snowplow_bad_parsed
-        FROM {{ ref('snowplow_bad_parsed') }}
-        {% if is_incremental() %}
+    SELECT
+        *,
+        TRUE AS snowplow_bad_parsed
+    FROM {{ ref('snowplow_bad_parsed') }}
+    {% if is_incremental() %}
 
         WHERE event_id NOT IN (SELECT DISTINCT event_id FROM {{ this }} WHERE snowplow_bad_parsed = TRUE)
 

--- a/data/transform/models/staging/snowplow/stg_snowplow__events.sql
+++ b/data/transform/models/staging/snowplow/stg_snowplow__events.sql
@@ -8,11 +8,11 @@ WITH blended_source AS (
     SELECT
         *,
         FALSE AS snowplow_bad_parsed
-        {% if env_var("MELTANO_ENVIRONMENT") == "cicd" %}
+    {% if env_var("MELTANO_ENVIRONMENT") == "cicd" %}
 
-        FROM raw.snowplow.events
-        WHERE derived_tstamp::TIMESTAMP >= DATEADD('day', -3, CURRENT_DATE)
-        {% else %}
+    FROM raw.snowplow.events
+    WHERE derived_tstamp::TIMESTAMP >= DATEADD('day', -3, CURRENT_DATE)
+    {% else %}
 
         FROM {{ source('snowplow', 'events') }}
 

--- a/data/transform/models/staging/snowplow/stg_snowplow__events_bad.sql
+++ b/data/transform/models/staging/snowplow/stg_snowplow__events_bad.sql
@@ -21,7 +21,8 @@ SELECT
     PARSE_JSON(jsontext):detail:data:payload:raw AS payload_raw,
     PARSE_JSON(jsontext):detail:data:payload:enriched AS payload_enriched,
     PARSE_JSON(jsontext):detail:data:processor AS processor
-{% if env_var("MELTANO_ENVIRONMENT") == "cicd" %}
+{% if env_var("MELTANO_ENVIRONMENT") == "cicd" %} -- noqa: disable=LT02
+-- SQLFluff disabled due to https://github.com/sqlfluff/sqlfluff/issues/4680
 FROM raw.snowplow.events_bad
 WHERE uploaded_at::TIMESTAMP >= DATEADD('day', -7, CURRENT_DATE)
 {% else %}

--- a/data/transform/models/staging/snowplow/stg_snowplow__events_bad.sql
+++ b/data/transform/models/staging/snowplow/stg_snowplow__events_bad.sql
@@ -21,11 +21,9 @@ SELECT
     PARSE_JSON(jsontext):detail:data:payload:raw AS payload_raw,
     PARSE_JSON(jsontext):detail:data:payload:enriched AS payload_enriched,
     PARSE_JSON(jsontext):detail:data:processor AS processor
-    {% if env_var("MELTANO_ENVIRONMENT") == "cicd" %}
-    FROM raw.snowplow.events_bad
-    WHERE uploaded_at::TIMESTAMP >= DATEADD('day', -7, CURRENT_DATE)
-    {% else %}
-
-    FROM {{ source('snowplow', 'events_bad') }}
-
-    {% endif %}
+{% if env_var("MELTANO_ENVIRONMENT") == "cicd" %}
+FROM raw.snowplow.events_bad
+WHERE uploaded_at::TIMESTAMP >= DATEADD('day', -7, CURRENT_DATE)
+{% else %}
+FROM {{ source('snowplow', 'events_bad') }}
+{% endif %}

--- a/data/transform/snapshots/meltanohub/snapshot_meltanohub_plugins.sql
+++ b/data/transform/snapshots/meltanohub/snapshot_meltanohub_plugins.sql
@@ -37,7 +37,8 @@
             variant
         FROM {{ source('tap_meltanohub', 'plugins') }}
         -- Handle hard deletes by only selecting most recent sync
-        QUALIFY RANK() OVER (
+        QUALIFY
+            RANK() OVER (
                 ORDER BY DATE_TRUNC('HOUR', _sdc_batched_at) DESC
             ) = 1
     )

--- a/data/transform/snapshots/spreadsheets_anywhere/snapshot_ssa_aws_ips.sql
+++ b/data/transform/snapshots/spreadsheets_anywhere/snapshot_ssa_aws_ips.sql
@@ -18,7 +18,8 @@
             service
         FROM {{ source('tap_spreadsheets_anywhere', 'aws_ips') }}
         -- Handle hard deletes by only selecting most recent sync
-        QUALIFY RANK() OVER (
+        QUALIFY
+            RANK() OVER (
                 ORDER BY DATE_TRUNC('MINUTE', _sdc_batched_at) DESC
             ) = 1
 

--- a/data/transform/snapshots/spreadsheets_anywhere/snapshot_ssa_azure_ips.sql
+++ b/data/transform/snapshots/spreadsheets_anywhere/snapshot_ssa_azure_ips.sql
@@ -20,7 +20,8 @@
             ):addressPrefixes AS properties
         FROM {{ source('tap_spreadsheets_anywhere', 'azure_ips') }}
         -- Handle hard deletes by only selecting most recent sync
-        QUALIFY RANK() OVER (
+        QUALIFY
+            RANK() OVER (
                 ORDER BY DATE_TRUNC('MINUTE', _sdc_batched_at) DESC
             ) = 1
 
@@ -39,7 +40,7 @@
             ) AS row_num
         FROM source,
             LATERAL FLATTEN(
-                input=>properties
+                input => properties
             ) AS addresses
 
     )

--- a/data/transform/snapshots/spreadsheets_anywhere/snapshot_ssa_gcp_ips.sql
+++ b/data/transform/snapshots/spreadsheets_anywhere/snapshot_ssa_gcp_ips.sql
@@ -19,7 +19,8 @@
             service
         FROM {{ source('tap_spreadsheets_anywhere', 'gcp_ips') }}
         -- Handle hard deletes by only selecting most recent sync
-        QUALIFY RANK() OVER (
+        QUALIFY
+            RANK() OVER (
                 ORDER BY DATE_TRUNC('MINUTE', _sdc_batched_at) DESC
             ) = 1
 

--- a/data/transform/tests/marts/telemetry/assert_cli_execution_base_projects.sql
+++ b/data/transform/tests/marts/telemetry/assert_cli_execution_base_projects.sql
@@ -2,5 +2,5 @@ SELECT project_dim.project_id
 FROM {{ ref('cli_executions_base') }}
 LEFT JOIN
     {{ ref('project_dim') }} ON
-        cli_executions_base.project_id = project_dim.project_id
+    cli_executions_base.project_id = project_dim.project_id
 WHERE project_dim.project_id IS NULL

--- a/data/transform/tests/marts/telemetry/base/assert_all_event_contexts_parsed.sql
+++ b/data/transform/tests/marts/telemetry/base/assert_all_event_contexts_parsed.sql
@@ -4,7 +4,8 @@ SELECT
     event_id,
     schema_name
 FROM {{ ref('context_base') }}
-WHERE schema_name
+WHERE
+    schema_name
     != 'iglu:com.snowplowanalytics.snowplow/web_page/jsonschema/1-0-0'
 
 MINUS

--- a/data/transform/tests/marts/telemetry/base/assert_structured_exec_counts.sql
+++ b/data/transform/tests/marts/telemetry/base/assert_structured_exec_counts.sql
@@ -34,7 +34,8 @@ SELECT
     *,
     100 * ((ga_event_count - struct_event_count) / ga_event_count) AS diff_pct
 FROM test
-WHERE ga_event_count > struct_event_count
+WHERE
+    ga_event_count > struct_event_count
     -- These are slightly off but are vs exec events
     AND command_category NOT LIKE 'meltano add %'
     AND command_category != 'meltano select'

--- a/data/transform/tests/marts/telemetry/base/assert_structured_exec_pipeline_runs.sql
+++ b/data/transform/tests/marts/telemetry/base/assert_structured_exec_pipeline_runs.sql
@@ -15,7 +15,8 @@
             se_label AS project_id,
             COUNT(event_id) AS event_count
         FROM {{ ref('stg_snowplow__events') }}
-        WHERE se_category IN ('meltano elt', 'meltano invoke', 'meltano run')
+        WHERE
+            se_category IN ('meltano elt', 'meltano invoke', 'meltano run')
             AND DATE_TRUNC(
                 'month', event_created_at
             )::DATE = DATEADD('month', -1, DATE_TRUNC('month', CURRENT_DATE))

--- a/data/transform/tests/marts/telemetry/base/assert_structured_pipeline_runs.sql
+++ b/data/transform/tests/marts/telemetry/base/assert_structured_pipeline_runs.sql
@@ -15,7 +15,8 @@
             se_label AS project_id,
             COUNT(event_id) AS event_count
         FROM {{ ref('stg_snowplow__events') }}
-        WHERE se_category IN ('meltano elt', 'meltano invoke', 'meltano run')
+        WHERE
+            se_category IN ('meltano elt', 'meltano invoke', 'meltano run')
             AND DATE_TRUNC(
                 'month', event_created_at
             )::DATE = DATEADD('month', -1, DATE_TRUNC('month', CURRENT_DATE))
@@ -28,8 +29,10 @@
             project_id,
             SUM(event_count) AS event_count
         FROM {{ ref('stg_ga__cli_events') }}
-        WHERE command_category IN (
-            'meltano elt', 'meltano invoke', 'meltano run')
+        WHERE
+            command_category IN (
+                'meltano elt', 'meltano invoke', 'meltano run'
+            )
             AND DATE_TRUNC(
                 'month', event_date
             )::DATE = DATEADD('month', -1, DATE_TRUNC('month', CURRENT_DATE))
@@ -83,8 +86,10 @@
         -- prod counts to compare against
         SELECT SUM(event_count) AS event_count
         FROM {{ ref('structured_executions') }}
-        WHERE command_category IN (
-            'meltano elt', 'meltano invoke', 'meltano run')
+        WHERE
+            command_category IN (
+                'meltano elt', 'meltano invoke', 'meltano run'
+            )
             AND DATE_TRUNC(
                 'month', event_created_date
             )::DATE = DATEADD('month', -1, DATE_TRUNC('month', CURRENT_DATE))

--- a/data/transform/tests/staging/snowplow/structured_events_schema.sql
+++ b/data/transform/tests/staging/snowplow/structured_events_schema.sql
@@ -7,5 +7,6 @@ SELECT DISTINCT
     event_format,
     event_version
 FROM {{ ref('stg_snowplow__events') }}
-WHERE event_vendor = 'com.google.analytics'
+WHERE
+    event_vendor = 'com.google.analytics'
     AND event_version != '1-0-0'

--- a/data/utilities/utilities.meltano.yml
+++ b/data/utilities/utilities.meltano.yml
@@ -2,7 +2,7 @@ plugins:
   utilities:
   - name: sqlfluff
     variant: sqlfluff
-    pip_url: sqlfluff==1.4.5; sqlfluff-templater-dbt==1.4.5; dbt-core~=1.3.0; dbt-snowflake~=1.3.0
+    pip_url: sqlfluff==2.0.3; sqlfluff-templater-dbt==2.0.3; dbt-core~=1.3.0; dbt-snowflake~=1.3.0
     settings:
     - name: user
       env: DBT_SNOWFLAKE_USER


### PR DESCRIPTION
Closes https://github.com/meltano/squared/issues/605

- bumps Sqlfluff version
- renames from code rules to name based rules for readability based on suggestion from 2.0 migration guide https://docs.sqlfluff.com/en/latest/releasenotes.html#upgrading-from-1-x-to-2-0
- removes configurations that are matching the default values as suggested in the migration guide
- I ran sqlfluff fix over all files since they did a full re-write of the indentation logic. I reviewed all of them to make sure they were just formatting changes.
