### PR TITLE
Run dbt seed daily

### DIFF
--- a/data/orchestrate/orchestrators.meltano.yml
+++ b/data/orchestrate/orchestrators.meltano.yml
@@ -162,6 +162,7 @@ jobs:
 
 - name: marts_refresh
   tasks:
+  - dbt-snowflake:seed
   - dbt-snowflake:run_marts
   - dbt-snowflake:test_marts
 


### PR DESCRIPTION
The internal-data repo has CSV files that we want to seed into Snowflake but right now seed is only run on a deployment of squared. That worked in the past but now that theres a new seed source we need to run it daily in case new additions were made to that CSV without manually running a seed on prod or without squared having been deployed recently.