### PR TITLE
mechanism to manually map org names and domains

### DIFF
--- a/data/transform/models/marts/telemetry/base/project_org_mapping.sql
+++ b/data/transform/models/marts/telemetry/base/project_org_mapping.sql
@@ -31,12 +31,17 @@ single_org_projects AS (
 
 SELECT DISTINCT
     base.org_name,
-    base.org_domain,
+    COALESCE(
+        project_org_domain_mapping.clean_org_domain,
+        base.org_domain
+    ) AS org_domain,
     base.project_id,
     'LEADMAGIC' AS org_source
 FROM base
 INNER JOIN single_org_projects
     ON base.project_id = single_org_projects.project_id
+LEFT JOIN {{ ref('internal_data', 'project_org_domain_mapping') }}
+    ON base.org_domain = project_org_domain_mapping.org_domain
 
 UNION ALL
 

--- a/data/transform/models/marts/telemetry/base/project_org_mapping.sql
+++ b/data/transform/models/marts/telemetry/base/project_org_mapping.sql
@@ -32,7 +32,7 @@ single_org_projects AS (
 SELECT DISTINCT
     base.org_name,
     COALESCE(
-        project_org_domain_mapping.clean_org_domain,
+        org_domain_override.clean_org_domain,
         base.org_domain
     ) AS org_domain,
     base.project_id,
@@ -40,8 +40,8 @@ SELECT DISTINCT
 FROM base
 INNER JOIN single_org_projects
     ON base.project_id = single_org_projects.project_id
-LEFT JOIN {{ ref('internal_data', 'project_org_domain_mapping') }}
-    ON base.org_domain = project_org_domain_mapping.org_domain
+LEFT JOIN {{ ref('internal_data', 'org_domain_override') }}
+    ON base.org_domain = org_domain_override.org_domain
 
 UNION ALL
 


### PR DESCRIPTION
Closes https://github.com/meltano/internal-data/issues/92

Following https://github.com/meltano/internal-data/pull/117 we have a seed file for mapping org names and domains if we need to override them. This solves a problem where we had subdomains that caused duplicates. For now this is a simple way to override them without having to have complex logic for parsing out subdomains.