### PR TITLE
revert snapshot use of rownum over rank

### DIFF
--- a/data/transform/snapshots/meltanohub/snapshot_meltanohub_plugins.sql
+++ b/data/transform/snapshots/meltanohub/snapshot_meltanohub_plugins.sql
@@ -38,7 +38,7 @@
         FROM {{ source('tap_meltanohub', 'plugins') }}
         -- Handle hard deletes by only selecting most recent sync
         QUALIFY
-            ROW_NUMBER() OVER (
+            RANK() OVER (
                 ORDER BY DATE_TRUNC('HOUR', _sdc_batched_at) DESC
             ) = 1
     )

--- a/data/transform/snapshots/spreadsheets_anywhere/snapshot_ssa_aws_ips.sql
+++ b/data/transform/snapshots/spreadsheets_anywhere/snapshot_ssa_aws_ips.sql
@@ -19,7 +19,7 @@
         FROM {{ source('tap_spreadsheets_anywhere', 'aws_ips') }}
         -- Handle hard deletes by only selecting most recent sync
         QUALIFY
-            ROW_NUMBER() OVER (
+            RANK() OVER (
                 ORDER BY DATE_TRUNC('MINUTE', _sdc_batched_at) DESC
             ) = 1
 

--- a/data/transform/snapshots/spreadsheets_anywhere/snapshot_ssa_azure_ips.sql
+++ b/data/transform/snapshots/spreadsheets_anywhere/snapshot_ssa_azure_ips.sql
@@ -21,7 +21,7 @@
         FROM {{ source('tap_spreadsheets_anywhere', 'azure_ips') }}
         -- Handle hard deletes by only selecting most recent sync
         QUALIFY
-            ROW_NUMBER() OVER (
+            RANK() OVER (
                 ORDER BY DATE_TRUNC('MINUTE', _sdc_batched_at) DESC
             ) = 1
 

--- a/data/transform/snapshots/spreadsheets_anywhere/snapshot_ssa_gcp_ips.sql
+++ b/data/transform/snapshots/spreadsheets_anywhere/snapshot_ssa_gcp_ips.sql
@@ -20,7 +20,7 @@
         FROM {{ source('tap_spreadsheets_anywhere', 'gcp_ips') }}
         -- Handle hard deletes by only selecting most recent sync
         QUALIFY
-            ROW_NUMBER() OVER (
+            RANK() OVER (
                 ORDER BY DATE_TRUNC('MINUTE', _sdc_batched_at) DESC
             ) = 1
 


### PR DESCRIPTION
In https://github.com/meltano/squared/pull/628 I updated the RANK references to ROW_NUMBER which didnt work the way I expected. The snapshots left very few rows. I noticed because the hub metrics were missing today. 

I'll also need to revert the snapshot changes in production by reverting `dbt_valid_to` updates from this morning.