### PR TITLE
fix null singer contrib titles

### DIFF
--- a/data/extract/extractors.meltano.yml
+++ b/data/extract/extractors.meltano.yml
@@ -57,7 +57,7 @@ plugins:
         start_date: '2020-01-01T00:00:00Z'
         key_properties: [id]
         name: azure_ips
-        pattern: ServiceTags_Public_20230508.json
+        pattern: ServiceTags_Public_20230522.json
         json_path: values
   - name: tap-slack
     variant: meltanolabs

--- a/data/transform/models/marts/community/singer_contributions.sql
+++ b/data/transform/models/marts/community/singer_contributions.sql
@@ -127,7 +127,7 @@ SELECT
         >= team_gitlab_ids.start_date
     ) AS is_team_contribution,
     stg_gitlab__issues.is_bot_user,
-    stg_gitlab__issues.title,
+    COALESCE(stg_gitlab__issues.title, '') AS title,
     stg_gitlab__issues.state,
     singer_repo_dim.is_fork,
     COALESCE(stg_meltanohub__plugins.is_default, FALSE) AS is_hub_default,
@@ -186,7 +186,7 @@ SELECT
         >= team_gitlab_ids.start_date
     ) AS is_team_contribution,
     stg_gitlab__merge_requests.is_bot_user,
-    stg_gitlab__merge_requests.title,
+    COALESCE(stg_gitlab__merge_requests.title, '') AS title,
     stg_gitlab__merge_requests.state,
     singer_repo_dim.is_fork,
     COALESCE(stg_meltanohub__plugins.is_default, FALSE) AS is_hub_default,


### PR DESCRIPTION
A test was failing in marts_refresh this morning due to null gitlab issue/MR titles ending up in the singer contributions table. Those are puposefully null because they came from the meltano org. I chose to coalesce them.