### PR TITLE
fix: add filter for gitlab projects that arent singer

### DIFF
--- a/data/transform/models/marts/community/singer_repo_dim.sql
+++ b/data/transform/models/marts/community/singer_repo_dim.sql
@@ -52,4 +52,10 @@ SELECT
     END AS connector_type,
     COALESCE(description, 'No Description') AS description
 FROM {{ ref('stg_gitlab__projects') }}
-WHERE project_namespace = 'hotglue'
+WHERE
+    project_namespace = 'hotglue'
+    AND (
+        LOWER(project_name) LIKE 'tap-%'
+        OR
+        LOWER(project_name) LIKE 'target-%'
+    )


### PR DESCRIPTION
I noticed a few gitlab contributions were being counted towards the singer metrics even though they werent actually connector repos. The github search streams are already filtered for repo name matching tap-* and target-* so I added an explicit filter to the gitlab repos query to do the same. This only accounted for ~50 contributions over time. I noticed because the PR/issue counts didnt add up to the total counts split by tap/targets, meaning some werent taps or targets.