### PR TITLE
feat: configure batch pipelines

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,7 +122,7 @@ jobs:
       with:
         name: output
         path: |
-          data/output/
+          output
 
   transform_tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,12 +117,6 @@ jobs:
     - run: meltano install --schedule=${{ matrix.extract-source }}
     # Run Test
     - run: meltano run ${{ matrix.extract-source }}
-    - name: Store Outputs for Debugging
-      uses: actions/upload-artifact@v3
-      with:
-        name: output
-        path: |
-          output
 
   transform_tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,6 +118,7 @@ jobs:
     # Run Test
     - run: meltano run ${{ matrix.extract-source }}
     - name: Store Outputs for Debugging
+      if: always()
       uses: actions/upload-artifact@v3
       with:
         name: output

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,7 +123,7 @@ jobs:
       with:
         name: output
         path: |
-          output
+          data/output/
 
   transform_tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,6 +117,12 @@ jobs:
     - run: meltano install --schedule=${{ matrix.extract-source }}
     # Run Test
     - run: meltano run ${{ matrix.extract-source }}
+    - name: Store Outputs for Debugging
+      uses: actions/upload-artifact@v3
+      with:
+        name: output
+        path: |
+          output
 
   transform_tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,7 +118,6 @@ jobs:
     # Run Test
     - run: meltano run ${{ matrix.extract-source }}
     - name: Store Outputs for Debugging
-      if: always()
       uses: actions/upload-artifact@v3
       with:
         name: output

--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,6 @@ cython_debug/
 
 # VS Code config
 .vscode/
+
+# Test data
+data/data/*

--- a/data/environments/cicd.meltano.yml
+++ b/data/environments/cicd.meltano.yml
@@ -67,7 +67,6 @@ environments:
           role: CICD
           warehouse: CICD
           default_target_schema: ${CI_BRANCH}_${MELTANO_EXTRACT__LOAD_SCHEMA}
-          clean_up_batch_files: false
       utilities:
       - name: dbt-snowflake
         config:

--- a/data/environments/cicd.meltano.yml
+++ b/data/environments/cicd.meltano.yml
@@ -67,6 +67,7 @@ environments:
           role: CICD
           warehouse: CICD
           default_target_schema: ${CI_BRANCH}_${MELTANO_EXTRACT__LOAD_SCHEMA}
+          clean_up_batch_files: false
       utilities:
       - name: dbt-snowflake
         config:

--- a/data/extract/extractors.meltano.yml
+++ b/data/extract/extractors.meltano.yml
@@ -43,7 +43,7 @@ plugins:
           format: jsonl
           compression: gzip
         storage:
-          root: file://
+          root: file://output/tap-cloudwatch/
   - name: tap-meltanohub
     variant: autoidm
     pip_url: git+https://github.com/pnadolny13/tap-meltanohub.git@update_dependencies
@@ -56,7 +56,7 @@ plugins:
           format: jsonl
           compression: gzip
         storage:
-          root: file://
+          root: file://output/tap-meltanohub/
   - name: tap-spreadsheets-anywhere
     variant: ets
     pip_url: git+https://github.com/ets/tap-spreadsheets-anywhere.git@5d9115985d3f9e7a568c6dcc68975f0c038253ff
@@ -98,7 +98,7 @@ plugins:
           format: jsonl
           compression: gzip
         storage:
-          root: file://
+          root: file://output/tap-slack/
     select:
     - users.*
     - channels.*
@@ -207,7 +207,7 @@ plugins:
           format: jsonl
           compression: gzip
         storage:
-          root: file://
+          root: file://output/tap-snowflake/
   - name: tap-snowflake-metrics
     inherit_from: tap-snowflake
     metadata:

--- a/data/extract/extractors.meltano.yml
+++ b/data/extract/extractors.meltano.yml
@@ -43,7 +43,7 @@ plugins:
           format: jsonl
           compression: gzip
         storage:
-          root: file://data
+          root: file://
   - name: tap-meltanohub
     variant: autoidm
     pip_url: git+https://github.com/pnadolny13/tap-meltanohub.git@update_dependencies
@@ -56,7 +56,7 @@ plugins:
           format: jsonl
           compression: gzip
         storage:
-          root: file://data
+          root: file://
   - name: tap-spreadsheets-anywhere
     variant: ets
     pip_url: git+https://github.com/ets/tap-spreadsheets-anywhere.git@5d9115985d3f9e7a568c6dcc68975f0c038253ff
@@ -98,7 +98,7 @@ plugins:
           format: jsonl
           compression: gzip
         storage:
-          root: file://data
+          root: file://
     select:
     - users.*
     - channels.*
@@ -207,7 +207,7 @@ plugins:
           format: jsonl
           compression: gzip
         storage:
-          root: file://data
+          root: file://
   - name: tap-snowflake-metrics
     inherit_from: tap-snowflake
     metadata:

--- a/data/extract/extractors.meltano.yml
+++ b/data/extract/extractors.meltano.yml
@@ -50,13 +50,6 @@ plugins:
     # pip_url: git+https://github.com/AutoIDM/tap-meltanohub.git@1b99b0ee7853b2d9db36de6afa16b15c1affce7b
     select:
     - plugins.*
-    config:
-      batch_config:
-        encoding:
-          format: jsonl
-          compression: gzip
-        storage:
-          root: file://output/tap-meltanohub/
   - name: tap-spreadsheets-anywhere
     variant: ets
     pip_url: git+https://github.com/ets/tap-spreadsheets-anywhere.git@5d9115985d3f9e7a568c6dcc68975f0c038253ff
@@ -202,12 +195,6 @@ plugins:
     config:
       account: epa06486
       password: ${SNOWFLAKE_PASSWORD}
-      batch_config:
-        encoding:
-          format: jsonl
-          compression: gzip
-        storage:
-          root: file://output/tap-snowflake/
   - name: tap-snowflake-metrics
     inherit_from: tap-snowflake
     metadata:

--- a/data/extract/extractors.meltano.yml
+++ b/data/extract/extractors.meltano.yml
@@ -30,7 +30,7 @@ plugins:
           __alias__: organizations_table
   - name: tap-cloudwatch
     variant: meltanolabs
-    pip_url: git+https://github.com/meltanolabs/tap-cloudwatch.git@0.3.0
+    pip_url: git+https://github.com/meltanolabs/tap-cloudwatch.git@0.4.0
     config:
       log_group_name: API-Gateway-Execution-Logs_i32s35df22/prod
       query: fields @timestamp, @message
@@ -38,11 +38,25 @@ plugins:
       start_date: '2022-12-08'
       aws_access_key_id: ${AWS_ACCESS_KEY_ID}
       aws_secret_access_key: ${AWS_SECRET_ACCESS_KEY}
+      batch_config:
+        encoding:
+          format: jsonl
+          compression: gzip
+        storage:
+          root: file://data
   - name: tap-meltanohub
     variant: autoidm
-    pip_url: git+https://github.com/AutoIDM/tap-meltanohub.git@1b99b0ee7853b2d9db36de6afa16b15c1affce7b
+    pip_url: git+https://github.com/pnadolny13/tap-meltanohub.git@update_dependencies
+    # pip_url: git+https://github.com/AutoIDM/tap-meltanohub.git@1b99b0ee7853b2d9db36de6afa16b15c1affce7b
     select:
     - plugins.*
+    config:
+      batch_config:
+        encoding:
+          format: jsonl
+          compression: gzip
+        storage:
+          root: file://data
   - name: tap-spreadsheets-anywhere
     variant: ets
     pip_url: git+https://github.com/ets/tap-spreadsheets-anywhere.git@5d9115985d3f9e7a568c6dcc68975f0c038253ff
@@ -71,7 +85,7 @@ plugins:
         json_path: values
   - name: tap-slack
     variant: meltanolabs
-    pip_url: git+https://github.com/MeltanoLabs/tap-slack.git@0.1.6
+    pip_url: git+https://github.com/MeltanoLabs/tap-slack.git@0.2.0
     config:
       start_date: '2021-01-01'
       auto_join_channels: false
@@ -79,6 +93,12 @@ plugins:
       - C01SK13R9NJ
       channel_types:
       - private_channel
+      batch_config:
+        encoding:
+          format: jsonl
+          compression: gzip
+        storage:
+          root: file://data
     select:
     - users.*
     - channels.*
@@ -182,6 +202,12 @@ plugins:
     config:
       account: epa06486
       password: ${SNOWFLAKE_PASSWORD}
+      batch_config:
+        encoding:
+          format: jsonl
+          compression: gzip
+        storage:
+          root: file://data
   - name: tap-snowflake-metrics
     inherit_from: tap-snowflake
     metadata:

--- a/data/output/README.md
+++ b/data/output/README.md
@@ -1,0 +1,2 @@
+Empty dirs for BATCH testing. Can Be deleted once this issue is resolved:
+https://github.com/meltano/sdk/issues/1014


### PR DESCRIPTION
Closes https://github.com/meltano/squared/issues/604

I configured all pipelines that could support batch to use it. tap-github and tap-dynamodb use stream maps so I couldnt use batch for those.

I will likely revert a few of these after we see them work in CI since theyre somewhat unnecessary for some cases i.e. tap-snowflake for 3 records.