### PR TITLE
fix: singer slack message duplicate join part 2

### DIFF
--- a/data/transform/macros/slack_message_generator.sql
+++ b/data/transform/macros/slack_message_generator.sql
@@ -1,3 +1,3 @@
 {% macro slack_message_generator() -%}
-'\n     • <' || html_url || ' | ' || organization_name || '/' || repo_name || ' #' || GET(split(html_url, '/'),  array_size(split(html_url, '/'))-1)::STRING || '> (*' || author_username || '*) - _' || title || '_'  || CASE WHEN singer_contributions.is_hub_listed THEN ' (:melty-flame: < ' || stg_meltanohub__plugins.docs || ' | _MeltanoHub Link_>)\n' ELSE '\n' END
+'\n     • <' || html_url || ' | ' || organization_name || '/' || repo_name || ' #' || GET(split(html_url, '/'),  array_size(split(html_url, '/'))-1)::STRING || '> (*' || author_username || '*) - _' || title || '_'  || CASE WHEN singer_contributions.is_hub_listed THEN ' (:melty-flame: < ' || hub_unique.docs || ' | _MeltanoHub Link_>)\n' ELSE '\n' END
 {%- endmacro %}

--- a/data/transform/models/publish/slack_notifications/singer_activity_notifications.sql
+++ b/data/transform/models/publish/slack_notifications/singer_activity_notifications.sql
@@ -19,6 +19,14 @@ WITH most_recent_date AS (
 
 ),
 
+hub_unique AS (
+    SELECT
+        repo,
+        MAX(docs) AS docs
+    FROM {{ ref('stg_meltanohub__plugins') }}
+    GROUP BY 1
+),
+
 base AS (
     SELECT
         ARRAY_AGG(
@@ -78,11 +86,11 @@ base AS (
         ) AS issues_closed
     FROM {{ ref('singer_contributions') }}
     CROSS JOIN most_recent_date
-    LEFT JOIN {{ ref('stg_meltanohub__plugins') }}
+    LEFT JOIN hub_unique
         ON
             LOWER(
                 singer_contributions.repo_url
-            ) = LOWER(stg_meltanohub__plugins.repo)
+            ) = LOWER(hub_unique.repo)
     WHERE singer_contributions.is_bot_user = FALSE
 ),
 


### PR DESCRIPTION
This PR https://github.com/meltano/squared/pull/666 fixed some but not all of the duplicate joins. I found this last one in the model that populates the data to be sent to slack.