### PR TITLE
fix: expand look back window to 10 days for late arriving events

### DIFF
--- a/data/transform/models/marts/telemetry/base/unstructured_parsing/context_base.sql
+++ b/data/transform/models/marts/telemetry/base/unstructured_parsing/context_base.sql
@@ -22,7 +22,7 @@ WHERE
 {% if is_incremental() %}
 
 AND event_unstruct.event_created_at >= (
-    SELECT DATEADD(days, -2, MAX(event_created_at)) FROM {{ this }}
+    SELECT DATEADD(days, -10, MAX(event_created_at)) FROM {{ this }}
 )
 AND event_unstruct.event_id NOT IN (SELECT event_id FROM {{ this }}) 
 


### PR DESCRIPTION
I noticed today that theres still 4 events that didnt get through and which might be causing downstream dbt test failures. The timestamps show that they were created 4-6 days ago but didnt arrive until yesterday so when we look back 1 day for new data they arent considered. I expanded the window to -10 days although this is still imperfect because I see a max of 150 days late (🙄 ) for events in the past, its rare but does happen. We'll likely have to handle them manually when it happens.

Another option could be to add jinja logic to the incremental block to run a full reload once a week/month to fix these types of things. I'll hold off on that for now but might consider it depending on how often this becomes a problem moving forward.