### PR TITLE
Refresh mart only mwf

### DIFF
--- a/data/extract/extractors.meltano.yml
+++ b/data/extract/extractors.meltano.yml
@@ -71,7 +71,7 @@ plugins:
         start_date: '2020-01-01T00:00:00Z'
         key_properties: [id]
         name: azure_ips
-        pattern: ServiceTags_Public_20230821.json
+        pattern: ServiceTags_Public_20230903.json
         json_path: values
   - name: tap-slack
     variant: meltanolabs

--- a/data/extract/extractors.meltano.yml
+++ b/data/extract/extractors.meltano.yml
@@ -71,7 +71,7 @@ plugins:
         start_date: '2020-01-01T00:00:00Z'
         key_properties: [id]
         name: azure_ips
-        pattern: ServiceTags_Public_20230903.json
+        pattern: ServiceTags_Public_20230904.json
         json_path: values
   - name: tap-slack
     variant: meltanolabs

--- a/data/orchestrate/orchestrators.meltano.yml
+++ b/data/orchestrate/orchestrators.meltano.yml
@@ -56,15 +56,15 @@ schedules:
   job: google_analytics_el
 
 - name: hub_metrics_publish
-  interval: 0 12 * * *
+  interval: 0 12 * * 1,3,5
   job: hub_metrics_publish
 
 - name: marts_refresh
-  interval: 0 8 * * *
+  interval: 0 8 * * 1,3,5
   job: marts_refresh
 
 - name: hubspot_publish
-  interval: 0 12 * * *
+  interval: 0 12 * * 1,3,5
   job: hubspot_publish
 
 - name: sample_schedule


### PR DESCRIPTION
@tayloramurphy I'm reducing the mart refresh schedule to Mon/Weds/Fri to save on snowflake compute since this data is less regularly tracked right now. Theoretically cutting our bill by more than half. Let me know if you think thats appropriate, I can do less or more.

The EL jobs and slack publish feeds will continue to run daily. The slack publish dbt steps use graph operators and very little compute so its lightweight do that every day.