### PR TITLE
chore: limit the amount of context data we parse

### DIFF
--- a/data/transform/models/marts/telemetry/base/unstructured_parsing/context_base.sql
+++ b/data/transform/models/marts/telemetry/base/unstructured_parsing/context_base.sql
@@ -18,6 +18,8 @@ WHERE
     event_unstruct.contexts IS NOT NULL
     AND context.value:schema::STRING
     != 'iglu:com.snowplowanalytics.snowplow/web_page/jsonschema/1-0-0'
+    -- limit to last 6 months for performance purposes
+    AND event_unstruct.event_created_at::DATE > DATEADD(MONTH, -6, CURRENT_DATE())
 
 {% if is_incremental() %}
 

--- a/data/transform/models/marts/telemetry/base/unstructured_parsing/context_cli.sql
+++ b/data/transform/models/marts/telemetry/base/unstructured_parsing/context_cli.sql
@@ -15,6 +15,7 @@ WITH base_1_0_0 AS (
         MAX(SPLIT_PART(schema_name, '/', -1)) AS schema_version
     FROM {{ ref('context_base') }}
     WHERE schema_name = 'iglu:com.meltano/cli_context/jsonschema/1-0-0'
+        AND context_base.event_created_at::DATE > DATEADD(MONTH, -6, CURRENT_DATE())
     GROUP BY 1
 ),
 
@@ -51,6 +52,7 @@ base_1_1_0_onward AS (
     WHERE
         schema_name LIKE 'iglu:com.meltano/cli_context/%'
         AND schema_name != 'iglu:com.meltano/cli_context/jsonschema/1-0-0'
+        AND context_base.event_created_at::DATE > DATEADD(MONTH, -6, CURRENT_DATE())
     GROUP BY 1
 
 )

--- a/data/transform/models/marts/telemetry/base/unstructured_parsing/context_environment.sql
+++ b/data/transform/models/marts/telemetry/base/unstructured_parsing/context_environment.sql
@@ -39,6 +39,7 @@ WITH base AS (
     FROM {{ ref('context_base') }}
     WHERE
         schema_name LIKE 'iglu:com.meltano/environment_context/%'
+        AND context_base.event_created_at::DATE > DATEADD(MONTH, -6, CURRENT_DATE())
     GROUP BY 1
 
 )

--- a/data/transform/models/marts/telemetry/base/unstructured_parsing/context_exception.sql
+++ b/data/transform/models/marts/telemetry/base/unstructured_parsing/context_exception.sql
@@ -15,6 +15,7 @@ WITH base AS (
     FROM {{ ref('context_base') }}
     WHERE
         schema_name LIKE 'iglu:com.meltano/exception_context/%'
+        AND context_base.event_created_at::DATE > DATEADD(MONTH, -6, CURRENT_DATE())
     GROUP BY 1
 
 )

--- a/data/transform/models/marts/telemetry/base/unstructured_parsing/context_identify.sql
+++ b/data/transform/models/marts/telemetry/base/unstructured_parsing/context_identify.sql
@@ -19,6 +19,7 @@ WITH base AS (
     FROM {{ ref('context_base') }}
     WHERE
         schema_name LIKE 'iglu:com.meltano/identify_context/%'
+        AND context_base.event_created_at::DATE > DATEADD(MONTH, -6, CURRENT_DATE())
     GROUP BY 1
 
 )

--- a/data/transform/models/marts/telemetry/base/unstructured_parsing/context_plugins.sql
+++ b/data/transform/models/marts/telemetry/base/unstructured_parsing/context_plugins.sql
@@ -15,6 +15,7 @@ WITH base AS (
     FROM {{ ref('context_base') }}
     WHERE
         schema_name LIKE 'iglu:com.meltano/plugins_context/%'
+        AND context_base.event_created_at::DATE > DATEADD(MONTH, -6, CURRENT_DATE())
 
 ),
 

--- a/data/transform/models/marts/telemetry/base/unstructured_parsing/context_project.sql
+++ b/data/transform/models/marts/telemetry/base/unstructured_parsing/context_project.sql
@@ -28,6 +28,7 @@ WITH base AS (
     FROM {{ ref('context_base') }}
     WHERE
         schema_name LIKE 'iglu:com.meltano/project_context/%'
+        AND context_base.event_created_at::DATE > DATEADD(MONTH, -6, CURRENT_DATE())
     GROUP BY 1
 
 )


### PR DESCRIPTION
We have too much data in the context_base table so performance is poor. The data volume is increasing with time so the last 6 months has more data than all before it. This is likely because more users are on newer versions of meltano that send our rich unstructured events and because usage has grown.

I manually truncated the context_base incremental table to remove all data before this year and made a backup table of the original. The table is transient but the backup is not so it will be properly persisted if we ever need that processed historical data. Since the context_base table will continue to grow and we'll have to manually prune it periodically, I created this PR which limits all downstream tables to filter only for 6 months of data so their performance should be relatively static even as the base table grows.