### PR TITLE
fix: temporarily remove github author names from slack notifications

### DIFF
--- a/data/transform/macros/github_activity_slack_message_generator.sql
+++ b/data/transform/macros/github_activity_slack_message_generator.sql
@@ -1,3 +1,3 @@
 {% macro github_activity_slack_message_generator() -%}
-'\n     • <' || contribution_url || ' | ' || repo_full_name || ' #' || contribution_number || '> (*' || author_username || '*)\n' 
+'\n     • <' || contribution_url || ' | ' || repo_full_name || ' #' || contribution_number || '> \n' 
 {%- endmacro %}

--- a/data/transform/macros/slack_message_generator.sql
+++ b/data/transform/macros/slack_message_generator.sql
@@ -1,3 +1,3 @@
 {% macro slack_message_generator() -%}
-'\n     • <' || html_url || ' | ' || organization_name || '/' || repo_name || ' #' || GET(split(html_url, '/'),  array_size(split(html_url, '/'))-1)::STRING || '> (*' || author_username || '*) - _' || title || '_'  || CASE WHEN singer_contributions.is_hub_listed THEN ' (:melty-flame: < ' || hub_unique.docs || ' | _MeltanoHub Link_>)\n' ELSE '\n' END
+'\n     • <' || html_url || ' | ' || organization_name || '/' || repo_name || ' #' || GET(split(html_url, '/'),  array_size(split(html_url, '/'))-1)::STRING || '> - _' || title || '_'  || CASE WHEN singer_contributions.is_hub_listed THEN ' (:melty-flame: < ' || hub_unique.docs || ' | _MeltanoHub Link_>)\n' ELSE '\n' END
 {%- endmacro %}


### PR DESCRIPTION
The slack messages werent being generated properly because for some reason github author id and username stopped coming through. Its in the login nested json and when I install the latest version of the tap locally I see those values populated but they arent making it to snowflake for some reason.